### PR TITLE
args.py: Select multiple scan channels

### DIFF
--- a/wifite/args.py
+++ b/wifite/args.py
@@ -59,10 +59,10 @@ class Arguments(object):
             action='store',
             dest='channel',
             metavar='[channel]',
-            type=int,
-            help=Color.s('Wireless channel to scan (default: {G}all 2Ghz channels{W})'))
+            help=Color.s('Wireless channel to scan e.g. {C}1,3-6{W} ' +
+                '(default: {G}all 2Ghz channels{W})'))
         glob.add_argument('--channel', help=argparse.SUPPRESS, action='store',
-                dest='channel', type=int)
+            dest='channel')
 
         glob.add_argument('-5',
             '--5ghz',

--- a/wifite/config.py
+++ b/wifite/config.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
 
 from .util.color import Color
 from .tools.macchanger import Macchanger
@@ -179,6 +180,10 @@ class Configuration(object):
                     'when scanning & attacking')
 
         if args.channel:
+            chn_arg_re = re.compile("^[0-9]+((,[0-9]+)|(-[0-9]+,[0-9]+))*(-[0-9]+)?$")
+            if not chn_arg_re.match(args.channel):
+                raise ValueError("Invalid channel! The format must be 1,3-6,9")
+
             cls.target_channel = args.channel
             Color.pl('{+} {C}option:{W} scanning for targets on channel ' +
                     '{G}%s{W}' % args.channel)


### PR DESCRIPTION
Remove the integer restriction for selecting a channel.
Doing so we pass the argument from wifite directly to
airodump which does support the format 1,3-7,11-13.

Added a regex which checks the channel argument value
and raises a ValueError exception in case an invalid
values is sent. Sending this value as in to airodump
would result in airodump crashing with no explanation.

Signed-off-by: Radu Nicolau <radunicolau102@gmail.com>