### PR TITLE
wifite/util/scanner: Don't check wps state if --no-wps is enabled

### DIFF
--- a/wifite/util/scanner.py
+++ b/wifite/util/scanner.py
@@ -31,7 +31,7 @@ class Scanner(object):
 
         # Loads airodump with interface/channel/etc from Configuration
         try:
-            with Airodump() as airodump:
+            with Airodump(skip_wps = Configuration.no_wps) as airodump:
                 # Loop until interrupted (Ctrl+C)
                 scan_start_time = time()
 


### PR DESCRIPTION
Removed checking to WPS state for nearby access points as
it slows down the scan and seems to cause issues if Wifite
scanning is ran for long periods of time.

Signed-off-by: Radu Nicolau <radunicolau102@gmail.com>