### PR TITLE
Fix wordlist name

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include README.md
-include wordlist-top4800-probable.txt
+include wordlist-probable.txt

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'wifite/util',
     ],
     data_files=[
-        ('share/dict', ['wordlist-top4800-probable.txt'])
+        ('share/dict', ['wordlist-probable.txt'])
     ],
     entry_points={
         'console_scripts': [

--- a/wifite/config.py
+++ b/wifite/config.py
@@ -97,8 +97,8 @@ class Configuration(object):
         cls.wordlist = None
         wordlists = [
             './wordlist-probable.txt',  # Local file (ran from cloned repo)
-            '/usr/share/dict/wordlist-top4800-probable.txt',  # setup.py with prefix=/usr
-            '/usr/local/share/dict/wordlist-top4800-probable.txt',  # setup.py with prefix=/usr/local
+            '/usr/share/dict/wordlist-probable.txt',  # setup.py with prefix=/usr
+            '/usr/local/share/dict/wordlist-probable.txt',  # setup.py with prefix=/usr/local
             # Other passwords found on Kali
             '/usr/share/wfuzz/wordlist/fuzzdb/wordlists-user-passwd/passwds/phpbb.txt',
             '/usr/share/fuzzdb/wordlists-user-passwd/passwds/phpbb.txt',


### PR DESCRIPTION
setup.py fails because of a missing file: wordlist-top4800-probable.txt
This file is not in the repo. I replaced wordlist-top4800-probable.txt with wordlist-probable.txt