### PR TITLE
Handle different structure in /usr/share/ieee-data/oui.txt

### DIFF
--- a/wifite/config.py
+++ b/wifite/config.py
@@ -117,12 +117,16 @@ class Configuration(object):
             manufacturers = './ieee-oui.txt'
 
         if os.path.exists(manufacturers):
+            cls.manufacturers = {}
             with open(manufacturers, "r") as f:
                 # Parse txt format into dict
-                lines = f.read().splitlines()
-                k = lambda line: line.split()[0]
-                v = lambda line: ' '.join(line.split()[1:3]).rstrip('.')
-                cls.manufacturers = {k(line):v(line) for line in lines}
+                for line in f:
+                    if not re.match(r"^\w", line):
+                        continue
+                    line = line.replace('(hex)', '').replace('(base 16)', '')
+                    fields = line.split()
+                    if len(fields) >= 2:
+                        cls.manufacturers[fields[0]] = " ".join(fields[1:]).rstrip('.')
 
         # WPS variables
         cls.wps_filter  = False  # Only attack WPS networks


### PR DESCRIPTION
That file has multi-line entries like those:

24-05-F5   (hex)                Integrated Device Technology (Malaysia) Sdn. Bhd.
2405F5     (base 16)            Integrated Device Technology (Malaysia) Sdn. Bhd.
                                Phase 3, Bayan Lepas FIZ
                                Bayan Lepas  Penang  11900
                                MY

Thus we skip lines starting with spaces and we drop the parenthesis to
get back to the plain text format of ieee-oui.txt.