### PR TITLE
Added Unstable OpenCL driver return case to hashcat.py

### DIFF
--- a/wifite/tools/hashcat.py
+++ b/wifite/tools/hashcat.py
@@ -20,7 +20,7 @@ class Hashcat(Dependency):
     def should_use_force():
         command = ['hashcat', '-I']
         stderr = Process(command).stderr()
-        return 'No devices found/left' in stderr
+        return 'No devices found/left' or 'Unstable OpenCL driver detected!' in stderr
 
     @staticmethod
     def crack_handshake(handshake, show_command=False):


### PR DESCRIPTION
Added should_use_force() return case for 'Unstable OpenCL driver detected!' error in Hashcat which is caused by some OpenCL Intel HD GPUs on Linux.