### PR TITLE
Updated hashcat.py to use new 22000 hash format

### DIFF
--- a/wifite/tools/hashcat.py
+++ b/wifite/tools/hashcat.py
@@ -34,7 +34,7 @@ class Hashcat(Dependency):
             command = [
                 'hashcat',
                 '--quiet',
-                '-m', '2500',
+                '-m', '22000',
                 hccapx_file,
                 Configuration.wordlist
             ]


### PR DESCRIPTION
Hashcat does not like using the older 2500 hash format with the new output from HcxPcapngTool. 22000 hash format should be used instead.