### PR TITLE
Fixed manufacturers not being loaded from /usr/share

### DIFF
--- a/wifite/config.py
+++ b/wifite/config.py
@@ -112,8 +112,8 @@ class Configuration(object):
                 cls.wordlist = wlist
                 break
 
-        if os.path.isfile('./usr/share/ieee-data/oui.txt'):
-            manufacturers = './usr/share/ieee-data/oui.txt'
+        if os.path.isfile('/usr/share/ieee-data/oui.txt'):
+            manufacturers = '/usr/share/ieee-data/oui.txt'
         else:
             manufacturers = './ieee-oui.txt'
 


### PR DESCRIPTION
Configuration.manufacturers would never detect the ieee-oui.txt file from /usr/share, so it would always fallback to the local directory.