### PR TITLE
Remove the broken and redundant entry_points in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,6 @@ setup(
     data_files=[
         ('share/dict', ['wordlist-probable.txt'])
     ],
-    entry_points={
-        'console_scripts': [
-            'wifite = wifite.wifite:entry_point'
-        ]
-    },
     license='GNU GPLv2',
     scripts=['bin/wifite'],
     description='Wireless Network Auditor for Linux & Android',


### PR DESCRIPTION
Hello,

The "entry_points" field in setup.py creates a broken entry_points for wifite.wifite (it does not exist).
And you already have a "scripts" field in the setup.py: it will install the correct bin/wifite script (an entry_point) as /usr/sbin/wifite
if you remove the "entry_points" field.

This PR fixes https://github.com/kimocoder/wifite2/issues/49