### PR TITLE
Added feature for skipping cracked APs

### DIFF
--- a/wifite/args.py
+++ b/wifite/args.py
@@ -167,6 +167,12 @@ class Arguments(object):
         glob.add_argument('--ignore-essid', help=argparse.SUPPRESS, action='append',
                 dest='ignore_essids', type=str)
 
+        glob.add_argument('-ic',
+            '--ignore-cracked',
+            action='store_true',
+            dest='ignore_cracked',
+            help=Color.s('Hides previously-cracked targets. (default: {G}off{W})'))
+
         glob.add_argument('--clients-only',
             action='store_true',
             dest='clients_only',

--- a/wifite/config.py
+++ b/wifite/config.py
@@ -49,6 +49,7 @@ class Configuration(object):
         cls.target_essid = None  # User-defined AP name
         cls.target_bssid = None  # User-defined AP BSSID
         cls.ignore_essids = None  # ESSIDs to ignore
+        cls.ignore_cracked = False # Ignore previously-cracked BSSIDs
         cls.clients_only = False  # Only show targets that have associated clients
         cls.all_bands = False  # Scan for both 2Ghz and 5Ghz channels
         cls.two_ghz = False  # Scan 2.4Ghz channels
@@ -302,6 +303,16 @@ class Configuration(object):
             cls.ignore_essids = args.ignore_essids
             Color.pl('{+} {C}option: {O}ignoring ESSID(s): {R}%s{W}' %
                      ', '.join(args.ignore_essids))
+
+        if args.ignore_cracked:
+            from .model.result import CrackResult
+            cracked_targets = CrackResult.load_all()
+            if not cracked_targets:
+                Color.pl('{!} {R}Previously-cracked access points not found in %s' % cls.cracked_file)
+                cls.ignore_cracked = False
+            else:
+                cls.ignore_cracked = [ item['bssid'] for item in cracked_targets ]
+                Color.pl('{+} {C}option: {O}ignoring {R}%s{O} previously-cracked targets' % len(cls.ignore_cracked))            
 
         if args.clients_only:
             cls.clients_only = True

--- a/wifite/tools/airodump.py
+++ b/wifite/tools/airodump.py
@@ -292,6 +292,9 @@ class Airodump(Dependency):
             elif Configuration.ignore_essids is not None and\
                     result[i].essid in Configuration.ignore_essids:
                 result.pop(i)
+            elif Configuration.ignore_cracked and\
+                    result[i].bssid in Configuration.ignore_cracked:
+                result.pop(i)
             elif bssid and result[i].bssid.lower() != bssid.lower():
                 result.pop(i)
             elif essid and result[i].essid and result[i].essid != essid:


### PR DESCRIPTION
Addresses issue #33. Shorthand parameter naming and print formatting can be changed as see fit. Additional clarification for BSSID filtering in argument description and variable naming might also be helpful for some.