### PR TITLE
Don't double quote tshark filter

### DIFF
--- a/wifite/tools/tshark.py
+++ b/wifite/tools/tshark.py
@@ -120,7 +120,7 @@ class Tshark(Dependency):
             '-r', capfile,  # Path to cap file
             '-n',  # Don't resolve addresses
             # Extract beacon frames
-            '-Y', '"wlan.fc.type_subtype == 0x08 || wlan.fc.type_subtype == 0x05"',
+            '-Y', 'wlan.fc.type_subtype == 0x08 || wlan.fc.type_subtype == 0x05',
         ]
         tshark = Process(command, devnull=False)
 


### PR DESCRIPTION
Otherwise, tshark fails and outputs the following to stedrr:
```
tshark: "wlan.fc.type_subtype == 0x08 || wlan.fc.type_subtype == 0x05" is neither a field nor a protocol name.
```
Consequently, `Tshark.bssid_essid_pairs` returns an empty list.

---

We found this issue when trying to run tests without `pyrit`. (https://github.com/NixOS/nixpkgs/pull/153151#issuecomment-1003659318) We encountered this failure:
```
======================================================================
ERROR: testAnalyze (test_Handshake.TestHandshake)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/source/tests/test_Handshake.py", line 27, in testAnalyze
    hs.analyze()
  File "/build/source/wifite/model/handshake.py", line 127, in analyze
    self.divine_bssid_and_essid()
  File "/build/source/wifite/model/handshake.py", line 38, in divine_bssid_and_essid
    pairs = self.pyrit_handshakes()  # Find bssid/essid pairs that have handshakes in Pyrit
  File "/build/source/wifite/model/handshake.py", line 109, in pyrit_handshakes
    return Pyrit.bssid_essid_with_handshakes(
  File "/build/source/wifite/tools/pyrit.py", line 28, in bssid_essid_with_handshakes
    pyrit = Process(command, devnull=False)
  File "/build/source/wifite/util/process.py", line 93, in __init__
    self.pid = Popen(command, stdout=sout, stderr=serr, stdin=stdin, cwd=cwd, bufsize=bufsize)
  File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/subprocess.py", line 1821, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'pyrit'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/build/source/tests/test_Handshake.py", line 29, in testAnalyze
    exit()
  File "/nix/store/rppr9s436950i1dlzknbmz40m2xqqnxc-python3-3.9.9/lib/python3.9/_sitebuiltins.py", line 26, in __call__
    raise SystemExit(code)
SystemExit: None
```

Since `Tshark.bssid_essid_pairs` was returning an empty list, wifite was then trying to find bssid/essid pairs using pyrit. See: https://github.com/kimocoder/wifite2/blob/8d67def1c0255ab393840366348a10109e5f9fb7/wifite/model/handshake.py#L34-L38

---

Final note: this was the commit that originally changed the quoting on this line: a4110b4cf9ee9ba649deb8947325e431919ad336
The original reasoning for adding this seems to be "otherwise tshark locks up". I can't reproduce that original behavior without additional details.

Moreover, a similar filter elsewhere in the code is not double quoted in this manner:
https://github.com/kimocoder/wifite2/blob/8d67def1c0255ab393840366348a10109e5f9fb7/wifite/model/handshake.py#L158