### PR TITLE
Fix: Ignore invalid indexes

### DIFF
--- a/wifite/util/scanner.py
+++ b/wifite/util/scanner.py
@@ -268,8 +268,12 @@ class Scanner(object):
                 for i in range(lower, min(len(self.targets), upper + 1)):
                     chosen_targets.append(self.targets[i])
             elif choice.isdigit():
-                choice = int(choice) - 1
-                chosen_targets.append(self.targets[choice])
+                choice = int(choice)
+                if choice > len(self.targets):
+                    Color.pl('    {!} {O}Invalid target index (%d)... ignoring' % choice)
+                    continue
+
+                chosen_targets.append(self.targets[choice - 1])
 
         return chosen_targets
 


### PR DESCRIPTION
A little check to avoid messing with the target list, in case the user has typed an out of bounds target index