### PR TITLE
Fix: Handle empty json to avoid errors

### DIFF
--- a/wifite/model/result.py
+++ b/wifite/model/result.py
@@ -113,9 +113,12 @@ class CrackResult(object):
     @classmethod
     def load_all(cls):
         if not os.path.exists(cls.cracked_file):
-                return []
+            return []
         with open(cls.cracked_file, 'r') as json_file:
-            json = loads(json_file.read())
+            try:
+                json = loads(json_file.read())
+            except ValueError:
+                return []
         return json
 
     @staticmethod


### PR DESCRIPTION
Handle empty json to avoid errors when using --ignore-cracked
Resolves #78 "Failure to launch the script when using --ignore-cracked"