### PR TITLE
Possible fix for encoding issue when reading the CSV output from airodump

### DIFF
--- a/wifite/tools/airodump.py
+++ b/wifite/tools/airodump.py
@@ -216,7 +216,7 @@ class Airodump(Dependency):
         """Returns list of Target objects parsed from CSV file."""
         targets = []
         import csv
-        with open(csv_filename, 'r') as csvopen:
+        with open(csv_filename, 'r', encoding='unicode_escape') as csvopen:
             lines = []
             for line in csvopen:
                 line = line.replace('\0', '')


### PR DESCRIPTION
I haven't managed to achieve the same error during the use of the tool, but this fix did work with an isolated test that I did. I hope it works.

Should mitigate #88 UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc0 in position 880: invalid start byte