### PR TITLE
fix: cracked.json being saved without ESSID and BSSID

### DIFF
--- a/wifite/model/result.py
+++ b/wifite/model/result.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-*
 
 from ..util.color import Color
 from ..config import Configuration
@@ -16,9 +16,7 @@ class CrackResult(object):
     cracked_file = Configuration.cracked_file
 
     def __init__(self):
-        self.bssid = None
         self.date = int(time.time())
-        self.essid = None
         self.loc = 'ND'
         self.readable_date = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(self.date))
 


### PR DESCRIPTION
Had an issue with my installation that would prevent it to save the AP name and BSSID. This made the trick.