### PR TITLE
Fix: Missing parameter 'channel' when outputting cracked.json

### DIFF
--- a/wifite/model/result.py
+++ b/wifite/model/result.py
@@ -140,6 +140,7 @@ class CrackResult(object):
         elif json['type'] == 'WPS':
             from .wps_result import CrackResultWPS
             result = CrackResultWPS(json['bssid'],
+                                    json['channel'],
                                     json['essid'],
                                     json['pin'],
                                     json['psk'])


### PR DESCRIPTION
Fixes #103 - missing parameter 'channel'