### PR TITLE
Allow airodump-ng to exit & get reaped

### DIFF
--- a/wifite/tools/airodump.py
+++ b/wifite/tools/airodump.py
@@ -69,6 +69,7 @@ class Airodump(Dependency):
         command = [
             'airodump-ng',
             self.interface,
+            '--background', '1', # Force "background mode" since we rely on csv instead of stdout
             '-a', # Only show associated clients
             '-w', self.csv_file_prefix, # Output file prefix
             '--write-interval', '1' # Write every second


### PR DESCRIPTION
`airodump-ng` actually never exits - it needs to be convinced to use its "background mode" (=close stdin? stop waiting for stdout buffer?), otherwise it hangs around in zombie mode until the `wifite` main process itself exits + causes an annoying little pause after scanning ends.

This patch just adds the missing command line parameter.

(This was originally PR derv82/wifite2/pull/436 because I was assuming it was the "most maintained" fork, but evidently I was mistaken)