### PR TITLE
Implement ignore feature

### DIFF
--- a/wifite/__main__.py
+++ b/wifite/__main__.py
@@ -45,7 +45,10 @@ class Wifite(object):
         from .util.crack import CrackHelper
 
         if Configuration.show_cracked:
-            CrackResult.display()
+            CrackResult.display('cracked')
+
+        elif Configuration.show_ignored:
+            CrackResult.display('ignored')
 
         elif Configuration.check_handshake:
             Handshake.check()

--- a/wifite/args.py
+++ b/wifite/args.py
@@ -479,7 +479,7 @@ class Arguments(object):
         commands.add_argument('--ignored',
                               action='store_true',
                               dest='ignored',
-                              help=Color.s('Print ignored and previously-cracked access points'))
+                              help=Color.s('Print ignored access points'))
 
         commands.add_argument('-cracked',
                               help=argparse.SUPPRESS,

--- a/wifite/args.py
+++ b/wifite/args.py
@@ -476,6 +476,11 @@ class Arguments(object):
                               dest='cracked',
                               help=Color.s('Print previously-cracked access points'))
 
+        commands.add_argument('--ignored',
+                              action='store_true',
+                              dest='ignored',
+                              help=Color.s('Print ignored and previously-cracked access points'))
+
         commands.add_argument('-cracked',
                               help=argparse.SUPPRESS,
                               action='store_true',

--- a/wifite/config.py
+++ b/wifite/config.py
@@ -45,6 +45,7 @@ class Configuration(object):
     scan_time = None
     show_bssids = None
     show_cracked = None
+    show_ignored = None
     show_manufacturers = None
     skip_crack = None
     target_bssid = None
@@ -209,6 +210,7 @@ class Configuration(object):
 
         # Commands
         cls.show_cracked = False
+        cls.show_ignored = False
         cls.check_handshake = None
         cls.crack_handshake = False
 
@@ -257,6 +259,8 @@ class Configuration(object):
         # Commands
         if args.cracked:
             cls.show_cracked = True
+        if args.ignored:
+            cls.show_ignored = True
         if args.check_handshake:
             cls.check_handshake = args.check_handshake
         if args.crack_handshake:
@@ -356,10 +360,11 @@ class Configuration(object):
             Color.pl('{+} {C}option: {O}ignoring ESSID(s): {R}%s{W}' %
                      ', '.join(args.ignore_essids))
 
+        from .model.result import CrackResult
+        cls.ignore_cracked = CrackResult.load_ignored_bssids(args.ignore_cracked)
+
         if args.ignore_cracked:
-            from .model.result import CrackResult
-            if cracked_targets := CrackResult.load_all():
-                cls.ignore_cracked = [item['bssid'] for item in cracked_targets]
+            if cls.ignore_cracked:
                 Color.pl('{+} {C}option: {O}ignoring {R}%s{O} previously-cracked targets' % len(cls.ignore_cracked))
 
             else:

--- a/wifite/model/ignored_result.py
+++ b/wifite/model/ignored_result.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from ..util.color import Color
+from ..model.result import CrackResult
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from os import devnull
+
+
+@contextmanager
+def suppress_stdout_stderr():
+    """A context manager that redirects stdout and stderr to devnull"""
+    with open(devnull, 'w') as fnull:
+        with redirect_stderr(fnull) as err, redirect_stdout(fnull) as out:
+            yield err, out
+
+
+class CrackResultIgnored(CrackResult):
+    def __init__(self, bssid, essid):
+        self.result_type = 'IGN'
+        self.bssid = bssid
+        self.essid = essid
+        super(CrackResultIgnored, self).__init__()
+
+    def dump(self):
+        if self.essid is not None:
+            Color.pl(f'{{+}} {"ESSID".rjust(12)}: {{C}}{self.essid}{{W}}')
+        Color.pl('{+} %s: {C}%s{W}' % ('BSSID'.rjust(12), self.bssid))
+
+    def print_single_line(self, longest_essid):
+        self.print_single_line_prefix(longest_essid)
+        Color.p('{G}%s{W}' % 'IGN'.ljust(9))
+        Color.pl('')
+
+    def to_dict(self):
+        with suppress_stdout_stderr():
+            print('@@@ to dict', self.__dict__)
+            return {
+                'type': self.result_type,
+                'date': self.date,
+                'essid': self.essid,
+                'bssid': self.bssid,
+            }
+
+
+if __name__ == '__main__':
+    crw = CrackResultIgnored('AA:BB:CC:DD:EE:FF', 'Test Router')
+    crw.dump()
+    crw.save()

--- a/wifite/model/result.py
+++ b/wifite/model/result.py
@@ -61,31 +61,39 @@ class CrackResult(object):
                     self.essid, Configuration.cracked_file))
                 return
 
+        Color.pl('{+} {C}%s{O} is now ignored in {G}%s{O}.' % (
+            self.essid, Configuration.cracked_file))
+
         saved_results.append(self.to_dict())
         with open(name, 'w') as fid:
             fid.write(dumps(saved_results, indent=2))
-        Color.pl('{+} saved crack result to {C}%s{W} ({G}%d total{W})'
+        Color.pl('{+} saved result to {C}%s{W} ({G}%d total{W})'
                  % (name, len(saved_results)))
 
     @classmethod
-    def display(cls):
-        """ Show cracked targets from cracked file """
+    def display(cls, result_type):
+        """ Show targets from results file """
         name = cls.cracked_file
         if not os.path.exists(name):
             Color.pl('{!} {O}file {C}%s{O} not found{W}' % name)
             return
 
-        with open(name, 'r') as fid:
-            cracked_targets = loads(fid.read())
+        targets = cls.load_all()
+        only_cracked = result_type == 'cracked'
 
-        if len(cracked_targets) == 0:
+        if only_cracked:
+            targets = [item for item in targets if item.get('type') != 'IGN']
+        else:
+            targets = [item for item in targets if item.get('type') == 'IGN']
+
+        if len(targets) == 0:
             Color.pl('{!} {R}no results found in {O}%s{W}' % name)
             return
 
-        Color.pl('\n{+} Displaying {G}%d{W} cracked target(s) from {C}%s{W}\n' % (
-            len(cracked_targets), name))
+        Color.pl('\n{+} Displaying {G}%d{W} cracked or ignored target(s) from {C}%s{W}\n' % (
+            len(targets), cls.cracked_file))
 
-        results = sorted([cls.load(item) for item in cracked_targets], key=lambda x: x.date, reverse=True)
+        results = sorted([cls.load(item) for item in targets], key=lambda x: x.date, reverse=True)
         longest_essid = max(len(result.essid or 'ESSID') for result in results)
 
         # Header
@@ -98,9 +106,10 @@ class CrackResult(object):
         Color.p('  ')
         Color.p('TYPE'.ljust(5))
         Color.p('  ')
-        Color.p('KEY')
-        Color.pl('{D}')
-        Color.p(' ' + '-' * (longest_essid + 17 + 19 + 5 + 11 + 12))
+        if only_cracked:
+            Color.p('KEY')
+            Color.pl('{D}')
+            Color.p(' ' + '-' * (longest_essid + 17 + 19 + 5 + 11 + 12))
         Color.pl('{W}')
         # Results
         for result in results:
@@ -117,6 +126,24 @@ class CrackResult(object):
             except ValueError:
                 return []
         return json
+
+    @classmethod
+    def load_ignored_bssids(cls, ignore_cracked = False):
+        json = cls.load_all()
+        ignored_bssids = [
+            item.get('bssid', '')
+            for item in json
+            if item.get('result_type') == 'IGN'
+        ]
+
+        if not ignore_cracked:
+            return ignored_bssids
+
+        return ignored_bssids + [
+            item.get('bssid', '')
+            for item in json
+            if item.get('result_type') != 'IGN'
+        ]
 
     @staticmethod
     def load(json):
@@ -149,10 +176,30 @@ class CrackResult(object):
                                       essid=json['essid'],
                                       pmkid_file=json['pmkid_file'],
                                       key=json['key'])
+            
+        else:
+            from .ignored_result import CrackResultIgnored
+            result = CrackResultIgnored(bssid=json['bssid'],
+                                        essid=json['essid'])
+
         result.date = json['date']
         result.readable_date = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(result.date))
         return result
 
+    @classmethod
+    def ignore_target(cls, target):
+        ignored_targets = cls.load_all()
+
+        for ignored_target in ignored_targets:
+            is_ignored = ignored_target == 'IGN'
+            bssid_match = target.bssid == ignored_target.get('bssid')
+            essid_match = target.essid == ignored_target.get('essid')
+            if is_ignored and bssid_match and essid_match:
+                return
+
+        from .ignored_result import CrackResultIgnored
+        ignored_target = CrackResultIgnored(target.bssid, target.essid)
+        ignored_target.save()
 
 if __name__ == '__main__':
     # Deserialize WPA object
@@ -176,5 +223,13 @@ if __name__ == '__main__':
     json = loads(
         '{"psk": "the psk", "bssid": "AA:BB:CC:DD:EE:FF", "pin": "01234567", "essid": "Test Router", '
         '"date": 1433403278, "type": "WPS"}')
+    obj = CrackResult.load(json)
+    obj.dump()
+
+    # Deserialize Ignored object
+    Color.pl('\nIgnored:')
+    json = loads(
+        '{"bssid": "AA:BB:CC:DD:EE:FF", "essid": "Test Router", '
+        '"date": 1433403278, "type": "IGN"}')
     obj = CrackResult.load(json)
     obj.dump()

--- a/wifite/model/result.py
+++ b/wifite/model/result.py
@@ -61,9 +61,6 @@ class CrackResult(object):
                     self.essid, Configuration.cracked_file))
                 return
 
-        Color.pl('{+} {C}%s{O} is now ignored in {G}%s{O}.' % (
-            self.essid, Configuration.cracked_file))
-
         saved_results.append(self.to_dict())
         with open(name, 'w') as fid:
             fid.write(dumps(saved_results, indent=2))
@@ -90,8 +87,8 @@ class CrackResult(object):
             Color.pl('{!} {R}no results found in {O}%s{W}' % name)
             return
 
-        Color.pl('\n{+} Displaying {G}%d{W} cracked or ignored target(s) from {C}%s{W}\n' % (
-            len(targets), cls.cracked_file))
+        Color.pl('\n{+} Displaying {G}%d{W} %s target(s) from {C}%s{W}\n' % (
+            len(targets), result_type, cls.cracked_file))
 
         results = sorted([cls.load(item) for item in targets], key=lambda x: x.date, reverse=True)
         longest_essid = max(len(result.essid or 'ESSID') for result in results)


### PR DESCRIPTION
Just a small contribution for wifite2: option to ignore targets on the fly.

## Summary by Sourcery

Implement an 'ignore' feature to allow users to skip specific targets during attacks and manage ignored targets. Enhance the display functionality to show both cracked and ignored targets, improving user control and visibility over attack results.

New Features:
- Introduce an 'ignore' feature that allows users to ignore specific targets during attacks, enhancing the flexibility of target management.

Enhancements:
- Add functionality to display ignored targets alongside cracked targets, providing users with more comprehensive result visibility.