### PR TITLE
Removed the "channel" field since it is not required and not saved

### DIFF
--- a/wifite/model/result.py
+++ b/wifite/model/result.py
@@ -164,8 +164,7 @@ class CrackResult(object):
             result = CrackResultWPS(bssid=json['bssid'],
                                     essid=json['essid'],
                                     pin=json['pin'],
-                                    psk=json['psk'],
-                                    channel=json['channel'])
+                                    psk=json['psk'])
 
         elif json['type'] == 'PMKID':
             from .pmkid_result import CrackResultPMKID


### PR DESCRIPTION
Loading cracked network was not working if there was a wps cracked network With this fix it now works normally.

## Summary by Sourcery

Bug Fixes:
- Fix loading of cracked networks by removing the unnecessary 'channel' field from the CrackResultWPS initialization.