### PR TITLE
Rename main script.

### DIFF
--- a/bin/wifite
+++ b/bin/wifite
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 
-from wifite import __main__
-__main__.entry_point()
+from wifite import wifite
+wifite.main()

--- a/wifite.py
+++ b/wifite.py
@@ -3,5 +3,5 @@
 # Note: This script runs Wifite from within a cloned git repo.
 # The script `bin/wifite` is designed to be run after installing (from /usr/sbin), not from the cwd.
 
-from wifite import __main__
-__main__.entry_point()
+from wifite import wifite
+wifite.main()

--- a/wifite/wifite.py
+++ b/wifite/wifite.py
@@ -101,7 +101,7 @@ class Wifite(object):
         Color.pl('{+} Finished attacking {C}%d{W} target(s), exiting' % attacked_targets)
 
 
-def entry_point():
+def main():
     try:
         wifite = Wifite()
         wifite.start()
@@ -118,4 +118,4 @@ def entry_point():
 
 
 if __name__ == '__main__':
-    entry_point()
+    main()


### PR DESCRIPTION
This is a rename proposal that:
* Avoids the usage of names with speacial meaning (using underscore in python should have implications).
* Tries to use common names or common practices (main instead of entry_point).

This is a small side quest while refactoring other things.

## Summary by Sourcery

Enhancements:
- Rename entry_point() to main() and update invocation in the script