### PR TITLE
Fix missing return in AttackPMKID.run() preventing result saving

### DIFF
--- a/wifite/attack/pmkid.py
+++ b/wifite/attack/pmkid.py
@@ -241,9 +241,9 @@ class AttackPMKID(Attack):
             self.view.add_log(f"Channel: {channel_display}")
 
         if self.do_airCRACK:
-            self.run_aircrack()
+            return self.run_aircrack()
         else:
-            self.run_hashcat()
+            return self.run_hashcat()
 
     def run_aircrack(self):
         with Airodump(channel=self.target.channel,


### PR DESCRIPTION
The AttackPMKID.run() method was not returning the result of run_hashcat() or run_aircrack().  This caused the main attack loop (AttackAll) to receive None instead of True when a PMKID was successfully cracked.

As a result:
1. The attack loop continued to the next step (WPA handshake capture) unnecessarily.
2. If the subsequent WPA capture failed, the target was marked as failed.
3. The successfully cracked PMKID password was never saved to cracked.json because the success flag was lost.

This commit adds the missing return statements to ensure the success status is propagated correctly, allowing Wifite to save the cracked key and stop attacking the target immediately.