### PR TITLE
Fix failed to arm interface on 5GHz by distinguishing band suffixes

### DIFF
--- a/wifite/tools/hcxdumptool.py
+++ b/wifite/tools/hcxdumptool.py
@@ -103,8 +103,11 @@ class HcxDumpTool(Dependency):
         if self.channel:
             # Add band suffix 'a' for 2.4GHz (most common)
             channel_str = str(self.channel)
-            if not channel_str[-1].isalpha():
-                channel_str += 'a'  # Default to 2.4GHz band
+            if channel_str.isdigit():
+                if int(channel_str) <= 14:
+                    channel_str += 'a'  # Default to 2.4GHz band
+                else:
+                    channel_str += 'b'
             command.extend(['-c', channel_str])
 
         # Note: hcxdumptool 7.x removed --filterlist_ap option


### PR DESCRIPTION
Description
Bug Description: When running Wifite2 with --hcxdump on 5GHz channels (e.g., channel 36, 40, 149), hcxdumptool fails to start with the error: failed to arm interface.

Root Cause: In wifite/tools/hcxdumptool.py, the previous code blindly appended the 'a' suffix (indicating 2.4GHz) to all numeric channels.
- Channel 6 becomes 6a (Valid for 2.4GHz).
- Channel 40 becomes 40a (Invalid: implies channel 40 on the 2.4GHz band).

This causes hcxdumptool (or the underlying driver) to reject the command because channel 40 does not exist on the 2.4GHz band.

The Fix: I have refactored the channel logic to remove the forced 'a' suffix for all channels. The code now checks the channel number to apply the correct band suffix:
- Channels <= 14: Appends 'a' (2.4GHz).
- Channels > 14: Appends 'b' (5GHz).

This ensures valid channel arguments are passed to the tool for both frequency bands.