### PR TITLE
feat(macchanger): add --random-mac-vendor flag and improve privacy with --random-mac

### DIFF
--- a/wifite/args.py
+++ b/wifite/args.py
@@ -297,7 +297,12 @@ against the real AP and captures valid passwords.
                           '--random-mac',
                           action='store_true',
                           dest='random_mac',
-                          help=Color.s('Randomize wireless card MAC address (default: {G}off{W})'))
+                          help=Color.s('Randomize wireless card MAC address completely (better privacy) (default: {G}off{W})'))
+
+        glob.add_argument('--random-mac-vendor',
+                          action='store_true',
+                          dest='random_mac_vendor',
+                          help=Color.s('Randomize wireless card MAC address but keep vendor bytes (better compatibility) (default: {G}off{W})'))
 
         glob.add_argument('-p',
                           action='store',

--- a/wifite/tools/macchanger.py
+++ b/wifite/tools/macchanger.py
@@ -61,7 +61,7 @@ class Macchanger(Dependency):
             Color.pl('\r{+} {C}macchanger{W}: reset mac address back to {C}%s{W} on {C}%s{W}' % (new_mac, iface))
 
     @classmethod
-    def random(cls):
+    def random(cls, full_random=True):
         from ..util.process import Process
         if not Process.exists('macchanger'):
             Color.pl('{!} {R}macchanger: {O}not installed')
@@ -72,7 +72,9 @@ class Macchanger(Dependency):
 
         # -r to use random MAC address
         # -e to keep vendor bytes the same
-        if cls.down_macch_up(iface, ['-e']):
+        option = "-r" if full_random else "-e"
+
+        if cls.down_macch_up(iface, [option]):
             cls.is_changed = True
             new_mac = Ip.get_mac(iface)
 


### PR DESCRIPTION
feat(args.py): add --random-mac-vendor to keep vendor bytes and --random-mac for full random mac

refactor(config.py): add random mac logic with conflict handling between flags

feat(macchanger.py): allow user to choose between -e (vendor) and -r (full random) for better privacy

Currently --random-mac uses macchanger -e which keeps vendor bytes (first 3 octets)
This leaks manufacturer information and enables device fingerprinting

Changes:
- --random-mac now uses -r (full random) for maximum privacy
- --random-mac-vendor uses -e (keep vendor) for compatibility
- Graceful handling when both flags are used (falls back to full random)
- Clear user feedback showing which mode is active

Example:
    wifite --random-mac              # full random (maximum privacy)
    wifite --random-mac-vendor       # vendor-preserved (better compatibility)
    wifite --random-mac --random-mac-vendor  # warns and uses full random

This gives users control over privacy vs compatibility while maintaining
backward compatibility with existing --random-mac usage