### PR TITLE
Potential fix for code scanning alert no. 16: Uncontrolled data used in path expression

### DIFF
--- a/wifite/attack/portal/server.py
+++ b/wifite/attack/portal/server.py
@@ -211,11 +211,13 @@ class PortalRequestHandler(BaseHTTPRequestHandler):
             
             # Fallback to file system if not cached
             portal_dir = os.path.dirname(os.path.abspath(__file__))
-            static_dir = os.path.join(portal_dir, 'static')
-            full_path = os.path.join(static_dir, file_path)
+            # Normalize static directory path
+            static_dir = os.path.realpath(os.path.join(portal_dir, 'static'))
+            # Build and normalize full path to requested file
+            full_path = os.path.realpath(os.path.join(static_dir, file_path))
             
             # Security check: ensure file is within static directory
-            if not os.path.abspath(full_path).startswith(static_dir):
+            if os.path.commonpath([static_dir, full_path]) != static_dir:
                 self._send_error_response(403, 'Forbidden')
                 return
             


### PR DESCRIPTION
Potential fix for [https://github.com/kimocoder/wifite2/security/code-scanning/16](https://github.com/kimocoder/wifite2/security/code-scanning/16)

In general, the fix is to normalize the constructed file path and ensure it is strictly contained within the intended static root directory before using it, using a robust comparison (for example, `os.path.commonpath` or a normalized prefix comparison). This avoids directory traversal where attackers try inputs like `/static/../../../../etc/passwd` or attempt to exploit symlinks.

For this specific code, the best minimally invasive fix is:

- Normalize `static_dir` to an absolute, normalized path once in `_serve_static_file`.
- Compute `full_path` using `os.path.join(static_dir, file_path)` as before.
- Normalize `full_path` with `os.path.realpath` (or at least `os.path.normpath`) to collapse `..` and follow symlinks.
- Replace the `startswith` check with a safer check using `os.path.commonpath([static_dir, full_path]) == static_dir`. This ensures `full_path` is inside `static_dir`, even if the attacker tries path traversal characters or absolute paths.
- Use the normalized `full_path` for the existence check and the file open.

Concretely, within `wifite/attack/portal/server.py`:

- In `_serve_static_file`, update how `static_dir` and `full_path` are computed.
- Replace the current check:

```python
portal_dir = os.path.dirname(os.path.abspath(__file__))
static_dir = os.path.join(portal_dir, 'static')
full_path = os.path.join(static_dir, file_path)

# Security check: ensure file is within static directory
if not os.path.abspath(full_path).startswith(static_dir):
    self._send_error_response(403, 'Forbidden')
    return
```

with logic that:

- normalizes `static_dir` via `os.path.realpath`, and
- computes `full_path = os.path.realpath(os.path.join(static_dir, file_path))`,
- checks `os.path.commonpath([static_dir, full_path]) == static_dir`.

No new helper methods are strictly necessary; the existing imports already include `os`, so no additional imports are required. All other behavior (caching, content type selection, responses) remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
