### PR TITLE
Potential fix for code scanning alert no. 13: Clear-text logging of sensitive information

### DIFF
--- a/wifite/util/interface_manager.py
+++ b/wifite/util/interface_manager.py
@@ -1707,10 +1707,19 @@ class InterfaceManager:
                         # Task 11.1: Log interface capabilities
                         log_info('InterfaceManager', 
                                 f'  {interface_name}: {interface_info.get_capability_summary()}')
+                        # Mask MAC address to avoid logging full hardware identifier
+                        masked_mac = interface_info.mac_address
+                        try:
+                            if isinstance(interface_info.mac_address, str) and interface_info.mac_address:
+                                parts = interface_info.mac_address.split(':')
+                                if len(parts) == 6:
+                                    masked_mac = ':'.join(parts[:3] + ['**', '**', '**'])
+                        except Exception:
+                            pass
                         log_debug('InterfaceManager', 
                                  f'  {interface_name} details: driver={interface_info.driver}, '
                                  f'chipset={interface_info.chipset}, phy={interface_info.phy}, '
-                                 f'mac={interface_info.mac_address}')
+                                 f'mac={masked_mac}')
                         log_debug('InterfaceManager', 
                                  f'  {interface_name} state: mode={interface_info.current_mode}, '
                                  f'up={interface_info.is_up}, connected={interface_info.is_connected}')

--- a/wifite/util/logger.py
+++ b/wifite/util/logger.py
@@ -93,10 +93,70 @@ class Logger:
         return cls._enabled and level >= cls._log_level
     
     @classmethod
+    def _sanitize_message(cls, message: str) -> str:
+        """
+        Best-effort sanitization to avoid logging sensitive data in clear text.
+
+        Currently masks:
+          - Known wpa-sec API key from Configuration.wpasec_api_key
+          - Command-line API key arguments like "-k <value>" and "--key <value>"
+          - MAC addresses in standard hex notation (aa:bb:cc:dd:ee:ff)
+        """
+        try:
+            # Import lazily to avoid circular imports during module initialization
+            from ..config import Configuration  # type: ignore
+        except Exception:
+            Configuration = None  # type: ignore
+
+        sanitized = message
+
+        # Mask configured wpa-sec API key if present in message
+        try:
+            if Configuration is not None and getattr(Configuration, "wpasec_api_key", None):
+                api_key = Configuration.wpasec_api_key
+                if isinstance(api_key, str) and api_key:
+                    masked_key = api_key[:4] + "*" * (len(api_key) - 4) if len(api_key) > 4 else "****"
+                    sanitized = sanitized.replace(api_key, masked_key)
+        except Exception:
+            # Never let sanitization break logging
+            pass
+
+        # Mask common CLI key patterns: "-k <value>" and "--key <value>"
+        try:
+            import re
+
+            def _mask_cli_key(match):
+                flag = match.group(1)
+                return f"{flag} ****"
+
+            sanitized = re.sub(r"(-k)\s+\S+", _mask_cli_key, sanitized)
+            sanitized = re.sub(r"(--key)\s+\S+", _mask_cli_key, sanitized)
+        except Exception:
+            pass
+
+        # Mask MAC addresses: aa:bb:cc:dd:ee:ff -> aa:bb:cc:**:**:**
+        try:
+            import re
+
+            def _mask_mac(match):
+                full = match.group(0)
+                parts = full.split(":")
+                if len(parts) == 6:
+                    return ":".join(parts[:3] + ["**", "**", "**"])
+                return full
+
+            sanitized = re.sub(r"\b([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b", _mask_mac, sanitized)
+        except Exception:
+            pass
+
+        return sanitized
+
+    @classmethod
     def _format_message(cls, level: str, module: str, message: str) -> str:
         """Format log message with timestamp and level."""
         timestamp = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-        return f"[{timestamp}] [{level:8s}] [{module:20s}] {message}"
+        safe_message = cls._sanitize_message(message)
+        return f"[{timestamp}] [{level:8s}] [{module:20s}] {safe_message}"
     
     @classmethod
     def _write_to_file(cls, formatted_message: str):

--- a/wifite/util/process.py
+++ b/wifite/util/process.py
@@ -151,7 +151,17 @@ class Process(object):
         self._devnull_handles = []
 
         cmd_str = " ".join(command) if isinstance(command, list) else str(command)
-        log_debug('Process', f'Creating process: {cmd_str}')
+        # Avoid logging sensitive arguments (e.g. API keys) in clear text
+        try:
+            import re
+            def _mask_cli_key(match):
+                flag = match.group(1)
+                return f"{flag} ****"
+            safe_cmd_str = re.sub(r"(-k)\s+\S+", _mask_cli_key, cmd_str)
+            safe_cmd_str = re.sub(r"(--key)\s+\S+", _mask_cli_key, safe_cmd_str)
+        except Exception:
+            safe_cmd_str = cmd_str
+        log_debug('Process', f'Creating process: {safe_cmd_str}')
         
         if Configuration.verbose > 1:
             Color.pe(f'\n {{C}}[?] {{W}} Executing: {{B}}{" ".join(command)}{{W}}')


### PR DESCRIPTION
Potential fix for [https://github.com/kimocoder/wifite2/security/code-scanning/13](https://github.com/kimocoder/wifite2/security/code-scanning/13)

General approach: prevent sensitive values (in particular `wpasec_api_key` and MAC addresses) from being written to logs in clear text, while keeping the rest of the debug information. The safest, minimal‑impact fix is to sanitize log messages at the logger boundary, so any accidental inclusion of secrets (API keys, tokens, MACs) is redacted before hitting disk or stderr. In addition, we can avoid logging the full wlancap2wpasec command (which currently includes the key) by redacting or masking the `-k` argument in that specific log message, and by not expanding the MAC address in debug logs.

Concretely:

1. In `wifite/util/logger.py`, add a private helper `_sanitize_message` that:
   - Replaces occurrences of `Configuration.wpasec_api_key` with a masked placeholder if available.
   - Masks common patterns where the key appears in commands, such as `-k <value>` or `--key <value>`.
   - Masks MAC addresses in common formats (`aa:bb:cc:dd:ee:ff`).
   Then call `_sanitize_message` inside `_format_message` so every log line benefits without changing call sites.

2. In `wifite/util/process.py`, change the debug message that logs `cmd_str` at process creation time so it uses a sanitized version of the command string before passing it to `log_debug`. Because the logger will also sanitize, this is mainly belt‑and‑suspenders; but we can at least avoid obviously printing `-k` arguments.

3. In `wifite/util/interface_manager.py`, avoid logging `interface_info.mac_address` directly in the debug line. We can either drop it entirely or mask it. To keep behavior similar, log a masked form (e.g. first three octets, rest as `**`).

All changes stay within the provided snippets and only add standard library uses; no new external packages are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
