### PR TITLE
fix(airodump): fix three critical bugs in file cleanup and CSV parsing

### DIFF
--- a/wifite/tools/airodump.py
+++ b/wifite/tools/airodump.py
@@ -143,14 +143,15 @@ class Airodump(Dependency):
             os.remove(fil)
 
         # Remove .cap and .xor files from pwd
-        for fil in os.listdir('.'):
-            if fil.startswith('replay_') and fil.endswith('.cap') or fil.endswith('.xor'):
-                os.remove(fil)
+        cwd = os.getcwd()
+        for fil in os.listdir(cwd):
+            if fil.startswith('replay_') and (fil.endswith('.cap') or fil.endswith('.xor')):
+                os.remove(os.path.join(cwd, fil))
 
         # Remove replay/cap/xor files from temp
         temp_dir = Configuration.temp()
         for fil in os.listdir(temp_dir):
-            if fil.startswith('replay_') and fil.endswith('.cap') or fil.endswith('.xor'):
+            if fil.startswith('replay_') and (fil.endswith('.cap') or fil.endswith('.xor')):
                 os.remove(os.path.join(temp_dir, fil))
 
     def get_targets(self, old_targets=None, apply_filter=True, target_archives=None):
@@ -227,7 +228,7 @@ class Airodump(Dependency):
         import csv
 
         with open(csv_filename, "rb") as rawdata:
-            encoding = chardet.detect(rawdata.read())['encoding']
+            encoding = chardet.detect(rawdata.read())['encoding'] or 'utf-8'
 
         with open(csv_filename, 'r', encoding=encoding, errors='ignore') as csvopen:
             lines = []


### PR DESCRIPTION
- Fix operator precedence bug in replay_/xor file deletion conditions: `a and b or c` was incorrectly deleting any .xor file regardless of the replay_ prefix; fixed with explicit parentheses: `a and (b or c)`

- Fix os.remove(fil) in CWD loop using bare filename instead of full path; now uses os.path.join(os.getcwd(), fil) matching the temp_dir loop pattern

- Fix chardet.detect() returning None for unrecognized encodings causing TypeError when passed to open(); now falls back to utf-8