### PR TITLE
fix: resolve all high-severity issues from scan report

### DIFF
--- a/wifite/tools/dependency.py
+++ b/wifite/tools/dependency.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import shlex
 import shutil
 import subprocess
 
@@ -79,7 +80,7 @@ class PackageManager:
             return False, 'No supported package manager found'
         try:
             result = subprocess.run(
-                cmd, shell=True, capture_output=True, text=True, timeout=300
+                shlex.split(cmd), shell=False, capture_output=True, text=True, timeout=300
             )
             output = (result.stdout + '\n' + result.stderr).strip()
             return result.returncode == 0, output

--- a/wifite/util/color.py
+++ b/wifite/util/color.py
@@ -78,9 +78,9 @@ class Color(object):
 
     @staticmethod
     def clear_entire_line():
-        import os
-        (rows, columns) = os.popen('stty size', 'r').read().split()
-        Color.p('\r' + (' ' * int(columns)) + '\r')
+        import shutil
+        columns = shutil.get_terminal_size(fallback=(80, 24)).columns
+        Color.p('\r' + (' ' * columns) + '\r')
 
     @staticmethod
     def pattack(attack_type, target, attack_name, progress):

--- a/wifite/util/logger.py
+++ b/wifite/util/logger.py
@@ -101,6 +101,10 @@ class Logger:
           - Known wpa-sec API key from Configuration.wpasec_api_key
           - Command-line API key arguments like "-k <value>" and "--key <value>"
           - MAC addresses in standard hex notation (aa:bb:cc:dd:ee:ff)
+          - WPA/WEP keys from aircrack "KEY FOUND! [ <key> ]" output
+          - Live passphrase progress "Current passphrase: <value>"
+          - Hashcat cracked output "hash*bssid*station*essid:<password>"
+          - Generic PSK/passphrase/password keyword-value pairs
         """
         try:
             # Import lazily to avoid circular imports during module initialization
@@ -121,10 +125,10 @@ class Logger:
             # Never let sanitization break logging
             pass
 
+        import re
+
         # Mask common CLI key patterns: "-k <value>" and "--key <value>"
         try:
-            import re
-
             def _mask_cli_key(match):
                 flag = match.group(1)
                 return f"{flag} ****"
@@ -136,8 +140,6 @@ class Logger:
 
         # Mask MAC addresses: aa:bb:cc:dd:ee:ff -> aa:bb:cc:**:**:**
         try:
-            import re
-
             def _mask_mac(match):
                 full = match.group(0)
                 parts = full.split(":")
@@ -146,6 +148,46 @@ class Logger:
                 return full
 
             sanitized = re.sub(r"\b([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b", _mask_mac, sanitized)
+        except Exception:
+            pass
+
+        # Mask aircrack "KEY FOUND! [ <key> ]" output
+        try:
+            sanitized = re.sub(r"(KEY FOUND!\s*\[)\s*\S.*?\s*(\])", r"\1 **** \2", sanitized)
+        except Exception:
+            pass
+
+        # Mask aircrack live progress "Current passphrase: <value>"
+        try:
+            sanitized = re.sub(
+                r"(Current\s+passphrase\s*:)\s*\S.*",
+                r"\1 ****",
+                sanitized,
+                flags=re.IGNORECASE,
+            )
+        except Exception:
+            pass
+
+        # Mask hashcat cracked output: trailing :<password> after PMKID/hash lines
+        # Format: hash*bssid*station*essid:password  or  hash:password
+        try:
+            sanitized = re.sub(
+                r"([0-9a-fA-F\*]{20,}:[^:\n]{0,64}):[^\n]+$",
+                r"\1:****",
+                sanitized,
+                flags=re.MULTILINE,
+            )
+        except Exception:
+            pass
+
+        # Mask generic keyword-value pairs: password/passphrase/psk followed by
+        # a delimiter (=, :, space) and a value
+        try:
+            sanitized = re.sub(
+                r"(?i)(password|passphrase|psk|wpa_psk|wpa_passphrase)\s*[=:]\s*\S+",
+                r"\1=****",
+                sanitized,
+            )
         except Exception:
             pass
 

--- a/wifite/util/scanner.py
+++ b/wifite/util/scanner.py
@@ -218,10 +218,10 @@ class Scanner(object):
     @staticmethod
     def clr_scr():
         import platform
-        import os
+        import subprocess
 
         cmdtorun = 'cls' if platform.system().lower() == "windows" else 'clear'
-        os.system(shlex_quote(cmdtorun))
+        subprocess.run([cmdtorun], check=False)
 
     def print_targets(self):
         """Prints targets selection menu (1 target per row)."""
@@ -290,15 +290,13 @@ class Scanner(object):
 
     @staticmethod
     def get_terminal_height():
-        import os
-        (rows, columns) = os.popen('stty size', 'r').read().split()
-        return int(rows)
+        import shutil
+        return shutil.get_terminal_size(fallback=(24, 80)).lines
 
     @staticmethod
     def get_terminal_width():
-        import os
-        (rows, columns) = os.popen('stty size', 'r').read().split()
-        return int(columns)
+        import shutil
+        return shutil.get_terminal_size(fallback=(24, 80)).columns
 
     def select_targets(self):
         """


### PR DESCRIPTION
color.py / scanner.py — replace deprecated os.popen('stty size') with shutil.get_terminal_size(fallback=...) which is safe in non-TTY contexts (piped/redirected output) and does not raise ValueError on empty output.

scanner.py — replace os.system() with subprocess.run([cmd]) for the clear-screen call, eliminating the shell spawn and making the intent explicit.

dependency.py — replace shell=True subprocess.run() with shell=False plus shlex.split() on the install command string, removing the shell injection vector in the package installer.

logger.py — extend _sanitize_message() to mask WPA/WEP credentials that may appear in logged output:
  - aircrack "KEY FOUND! [ <key> ]" lines
  - aircrack live "Current passphrase: <value>" progress lines
  - hashcat cracked hash:password output
  - generic password/passphrase/psk keyword-value pairs
  - consolidate duplicate `import re` into a single import