### PR TITLE
fix: resolve two medium-severity issues

### DIFF
--- a/wifite/tools/airodump.py
+++ b/wifite/tools/airodump.py
@@ -224,11 +224,14 @@ class Airodump(Dependency):
     def get_targets_from_csv(csv_filename):
         """Returns list of Target objects parsed from CSV file."""
         targets2 = []
-        import chardet
         import csv
 
-        with open(csv_filename, "rb") as rawdata:
-            encoding = chardet.detect(rawdata.read())['encoding'] or 'utf-8'
+        try:
+            import chardet
+            with open(csv_filename, "rb") as rawdata:
+                encoding = chardet.detect(rawdata.read())['encoding'] or 'utf-8'
+        except ImportError:
+            encoding = 'utf-8'
 
         with open(csv_filename, 'r', encoding=encoding, errors='ignore') as csvopen:
             lines = []

--- a/wifite/util/logger.py
+++ b/wifite/util/logger.py
@@ -78,8 +78,10 @@ class Logger:
                 if log_dir and not os.path.exists(log_dir):
                     os.makedirs(log_dir, mode=0o700)
                 
-                # Write header
-                with open(log_file, 'a') as f:
+                # Write header — open with explicit 0o600 so the log file
+                # is owner-readable only, regardless of the process umask.
+                fd = os.open(log_file, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+                with os.fdopen(fd, 'a') as f:
                     f.write(f"\n{'='*80}\n")
                     f.write(f"Wifite2 Log - {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
                     f.write(f"{'='*80}\n")


### PR DESCRIPTION
airodump.py — wrap `import chardet` in a try/except ImportError so that a missing chardet package falls back to utf-8 encoding instead of crashing with an ImportError at runtime during a scan.

logger.py — create the log file via os.open() with explicit mode 0o600 (owner read/write only) instead of relying on the process umask, which could leave the file world-readable on systems with a permissive umask. Directory creation already used 0o700; the file now matches.