### PR TITLE
Fix 3 failing tests: path assertion, mock parameter mismatch, unmocke…

### DIFF
--- a/tests/test_hcxdumptool.py
+++ b/tests/test_hcxdumptool.py
@@ -199,11 +199,11 @@ class TestHcxDumpToolPassive(unittest.TestCase):
         """Test initialization with default output file"""
         mock_temp.return_value = '/tmp/wifite_'
         Configuration.interface = 'wlan0'
-        
+
         tool = HcxDumpToolPassive()
-        
+
         self.assertEqual(tool.interface, 'wlan0')
-        self.assertEqual(tool.output_file, '/tmp/wifite_passive_pmkid.pcapng')
+        self.assertEqual(tool.output_file, '/tmp/wifite_/passive_pmkid.pcapng')
 
     @patch('wifite.tools.hcxdumptool.Configuration.initialize')
     def test_initialization_no_interface_raises_error(self, mock_config_init):

--- a/tests/test_system_check.py
+++ b/tests/test_system_check.py
@@ -116,7 +116,7 @@ class TestSystemCheckEnvironment(unittest.TestCase):
     @patch('shutil.which', return_value=None)
     @patch('subprocess.run')
     def test_non_root_fails(self, mock_run, mock_which, mock_isdir, mock_exists,
-                             mock_uname, mock_name, mock_uid):
+                             mock_uname, mock_uid):
         mock_uname.return_value = MagicMock(sysname='Linux', release='6.1.0')
         mock_run.return_value = MagicMock(returncode=1, stdout='', stderr='')
 
@@ -200,7 +200,8 @@ class TestSystemCheckInterfaces(unittest.TestCase):
     @patch('os.listdir')
     @patch('os.path.isdir')
     @patch('subprocess.run')
-    def test_no_interfaces(self, mock_run, mock_isdir, mock_listdir):
+    @patch('wifite.tools.iw.Iw.get_interfaces', return_value=[])
+    def test_no_interfaces(self, mock_iw, mock_run, mock_isdir, mock_listdir):
         mock_listdir.return_value = ['lo', 'eth0']
         mock_isdir.return_value = False  # no /wireless subdir
 


### PR DESCRIPTION
…d fallback

- test_initialization_with_defaults: Fix expected path to match os.path.join output ('/tmp/wifite_/passive_pmkid.pcapng' not '/tmp/wifite_passive_pmkid.pcapng')
- test_non_root_fails: Remove extra mock_name parameter since @patch('os.name', 'posix') with a concrete replacement value does not inject a mock argument
- test_no_interfaces: Mock Iw.get_interfaces() fallback which uses Process.call (not subprocess.run) and was returning real system interfaces

https://claude.ai/code/session_016fLGtMyCk1GEeMnKeyedx4