### PR TITLE
Fix 13 pytest warnings by registering timeout marker and removing inv…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,9 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short"
-timeout = 30
+markers = [
+    "timeout(seconds): set a timeout for the test (requires pytest-timeout)",
+]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
…alid config

Remove the `timeout = 30` config option (requires pytest-timeout plugin to be installed) and register the `timeout` marker to eliminate PytestUnknownMarkWarning across all test files.