### PR TITLE
Fix Process.call() passing string commands to Popen without splitting

### DIFF
--- a/wifite/util/interface_manager.py
+++ b/wifite/util/interface_manager.py
@@ -1136,9 +1136,12 @@ class InterfaceManager:
     
     def __del__(self):
         """Cleanup on deletion."""
-        import contextlib
-        with contextlib.suppress(Exception):
-            self.cleanup_all()
+        try:
+            import contextlib
+            with contextlib.suppress(Exception):
+                self.cleanup_all()
+        except ImportError:
+            pass
     
     # ========================================================================
     # Interface Detection and Capability Checking (Task 2)

--- a/wifite/util/process.py
+++ b/wifite/util/process.py
@@ -108,9 +108,10 @@ class Process:
     def call(command, cwd=None, shell=False):
         """ Calls a command (either string or list of args). Returns (stdout, stderr) """
         if isinstance(command, str) and not shell:
-            # Only enable shell mode if explicitly requested
+            # Split string commands into list of args for Popen when not using shell mode
             if Configuration.verbose > 1:
                 Color.pe(f'\n {{C}}[?]{{W}} Executing: {{B}}{command}{{W}}')
+            command = command.split()
         elif shell:
             if Configuration.verbose > 1:
                 Color.pe(f'\n {{C}}[?] {{W}} Executing (Shell): {{B}}{command}{{W}}')


### PR DESCRIPTION
When shell=False (default), subprocess.Popen expects a list of args, not a string. Passing a string like 'iw dev' caused Popen to look for an executable literally named 'iw dev', resulting in FileNotFoundError.

Split string commands into arg lists in Process.call(), matching the existing behavior in Process.__init__. Also guard __del__ in InterfaceManager against ImportError during Python shutdown.

https://claude.ai/code/session_011L2mVc8fKRMrkc3Mgahkpy