### PR TITLE
Fix 4-way handshake attack being skipped after PMKID capture

### DIFF
--- a/wifite/attack/pmkid.py
+++ b/wifite/attack/pmkid.py
@@ -242,12 +242,12 @@ class AttackPMKID(Attack):
             Color.pl('\n {O}[{R}!{O}] Note: PMKID attacks are not possible because you do not have {C}%s{O}.{W}'
                      % Hashcat.dependency_name)
 
-        return True  # Even if we don't crack it, capturing a PMKID is 'successful'
+        return self.success  # Only consider attack successful if cracking succeeded
 
     def _handle_hashcat_failure(self, message):
         Color.pl(message)
         self.success = False
-        return True
+        return False
 
     def run(self):
         # Start TUI view if available


### PR DESCRIPTION
The _handle_hashcat_failure() method in AttackPMKID was returning True (indicating success) even though the attack failed. This caused the attack loop in all.py to break early, preventing the handshake attack from ever running. This was especially visible when --skip-crack was used: PMKID would be captured, skip-crack would prevent cracking, but the True return value would mark the target as completed and skip the handshake attack entirely.

Also fixed run_hashcat() to return self.success instead of always True, so the attack loop only stops when PMKID cracking actually succeeds.