### PR TITLE
fix: mask sensitive credentials in log output (CWE-312)

### DIFF
--- a/wifite/attack/eviltwin.py
+++ b/wifite/attack/eviltwin.py
@@ -19,7 +19,7 @@ from ..model.eviltwin_result import CrackResultEvilTwin
 from ..config import Configuration
 from ..util.color import Color
 from ..util.timer import Timer
-from ..util.logger import log_info, log_error, log_warning, log_debug
+from ..util.logger import log_info, log_error, log_warning, log_debug, mask_sensitive
 from ..util.client_monitor import ClientMonitor, ClientConnection
 from ..util.cleanup import CleanupManager
 from ..util.adaptive_deauth import AdaptiveDeauthManager
@@ -1412,7 +1412,7 @@ class EvilTwin(Attack):
             
             # Log the attempt
             if success:
-                log_info('EvilTwin', f'Valid credentials from {mac_address}: {password}')
+                log_info('EvilTwin', f'Valid credentials from {mac_address}: {mask_sensitive(password)}')
                 Color.pl('\n{+} {G}SUCCESS! Valid credentials captured:{W}')
                 Color.pl('    {C}From:{W} {G}%s{W}' % mac_address)
                 Color.pl('    {C}Password:{W} {G}%s{W}' % password)
@@ -1457,7 +1457,7 @@ class EvilTwin(Attack):
             portal_template=getattr(Configuration, 'evil_twin_portal_template', 'generic')
         )
         
-        log_info('EvilTwin', f'Created result for {self.target.essid}: {password}')
+        log_info('EvilTwin', f'Created result for {self.target.essid}: {mask_sensitive(password)}')
         return result
     
     def _setup_client_monitor(self, hostapd_log: str, dnsmasq_log: str):

--- a/wifite/attack/pmkid.py
+++ b/wifite/attack/pmkid.py
@@ -10,7 +10,7 @@ from ..util.output import OutputManager
 from ..model.pmkid_result import CrackResultPMKID
 from ..tools.airodump import Airodump
 from ..util.wpasec_uploader import WpaSecUploader
-from ..util.logger import log_debug, log_info, log_warning, log_error
+from ..util.logger import log_debug, log_info, log_warning, log_error, mask_sensitive
 from threading import Thread, active_count
 import os
 import time
@@ -479,7 +479,7 @@ class AttackPMKID(Attack):
             key = Hashcat.crack_pmkid(pmkid_file)
 
         if key is not None:
-            log_info('AttackPMKID', f'PMKID cracked successfully! Password: {key}')
+            log_info('AttackPMKID', f'PMKID cracked successfully! Password: {mask_sensitive(key)}')
             return self._handle_pmkid_crack_success(key, pmkid_file)
         # Failed to crack.
         if Configuration.wordlist is not None:
@@ -495,7 +495,7 @@ class AttackPMKID(Attack):
         # Successfully cracked.
         if self.view:
             self.view.add_log(f"Successfully cracked PMKID!")
-            self.view.add_log(f"Password: {key}")
+            self.view.add_log(f"Password: {mask_sensitive(key)}")
             self.view.update_progress({
                 'progress': 1.0,
                 'status': 'PMKID cracked successfully!',

--- a/wifite/tools/bully.py
+++ b/wifite/tools/bully.py
@@ -326,7 +326,8 @@ class Bully(Attack, Dependency):
 
         if self.cracked_pin and self.cracked_key:
             if self.attack_view:
-                self.attack_view.add_log(f"SUCCESS! Cracked WPS Key: {self.cracked_key}")
+                from ..util.logger import mask_sensitive
+                self.attack_view.add_log(f"SUCCESS! Cracked WPS Key: {mask_sensitive(self.cracked_key)}")
                 self.attack_view.update_progress({
                     'progress': 1.0,
                     'status': 'WPS Cracked!',

--- a/wifite/tools/reaver.py
+++ b/wifite/tools/reaver.py
@@ -288,7 +288,8 @@ class Reaver(Attack, Dependency):
                 # Reaver provided PSK
                 if self.attack_view:
                     self.attack_view.add_log(f"SUCCESS! Cracked WPS PIN: {pin}")
-                    self.attack_view.add_log(f"PSK (Password): {psk}")
+                    from ..util.logger import mask_sensitive
+                    self.attack_view.add_log(f"PSK (Password): {mask_sensitive(psk)}")
                     self.attack_view.update_progress({
                         'progress': 1.0,
                         'status': 'WPS Cracked!',

--- a/wifite/ui/attack_view.py
+++ b/wifite/ui/attack_view.py
@@ -1152,7 +1152,8 @@ class EvilTwinAttackView(AttackView):
         if success:
             self.successful_attempts += 1
             # Use rich text formatting for success
-            self.add_log(f"[bold green]✓[/bold green] Valid credentials from {mac_address}: [bold]{password}[/bold]", timestamp=True)
+            from ..util.logger import mask_sensitive
+            self.add_log(f"[bold green]✓[/bold green] Valid credentials from {mac_address}: [bold]{mask_sensitive(password)}[/bold]", timestamp=True)
             # Update phase to show success
             self.set_attack_phase("Validating")
             

--- a/wifite/util/logger.py
+++ b/wifite/util/logger.py
@@ -365,3 +365,22 @@ def log_critical(module: str, message: str, exc: Optional[Exception] = None):
 def log_exception(module: str, message: str):
     """Log current exception."""
     Logger.exception(module, message)
+
+
+def mask_sensitive(value: str) -> str:
+    """Mask a sensitive value (e.g. password, key) for safe logging.
+
+    Shows the first 2 characters followed by asterisks.  Values of
+    2 characters or fewer are fully masked.
+
+    Args:
+        value: The sensitive string to mask.
+
+    Returns:
+        A masked version of *value* that is safe to include in logs.
+    """
+    if not value:
+        return '****'
+    if len(value) <= 2:
+        return '*' * len(value)
+    return value[:2] + '*' * (len(value) - 2)


### PR DESCRIPTION
Passwords, PSKs, and WPA keys were being logged in clear text across multiple modules (eviltwin, pmkid, reaver, bully, attack_view). Added a mask_sensitive() helper to the logger utility and applied it at every call site so that only the first two characters of a secret are ever written to logs or the TUI log panel.

Resolves code-scanning alert #21 (clear-text logging of sensitive information).