### PR TITLE
Fix PMKID skip-crack message to display on a new line

### DIFF
--- a/wifite/attack/pmkid.py
+++ b/wifite/attack/pmkid.py
@@ -225,7 +225,7 @@ class AttackPMKID(Attack):
             if self.view:
                 self.view.add_log("Skipping crack phase (--skip-crack flag)")
             return self._handle_hashcat_failure(
-                '{+} Not cracking pmkid because {C}skip-crack{W} was used{W}')
+                '\n{+} Not cracking pmkid because {C}skip-crack{W} was used{W}')
 
         # Crack it.
         if Process.exists(Hashcat.dependency_name):


### PR DESCRIPTION
The "[+] Not cracking pmkid because skip-crack was used" message was appearing on the same line as the PMKID CAPTURE status line. Added a newline prefix so it displays on its own line.