### PR TITLE
Add directory support for --dict switch

### DIFF
--- a/wifite/args.py
+++ b/wifite/args.py
@@ -759,10 +759,10 @@ against the real AP and captures valid passwords.
         wpa.add_argument('--dict',
                          action='store',
                          dest='wordlist',
-                         metavar='[file]',
+                         metavar='[file/directory]',
                          type=str,
                          help=Color.s(
-                             'File containing passwords for cracking (default: {G}%s{W})') % self.config.wordlist)
+                             'File or directory containing wordlists for cracking (default: {G}%s{W})') % self.config.wordlist)
 
         wpa.add_argument('--wpadt',
                          action='store',

--- a/wifite/attack/pmkid.py
+++ b/wifite/attack/pmkid.py
@@ -468,15 +468,25 @@ class AttackPMKID(Attack):
 
             key = None
         else:
-            log_info('AttackPMKID', f'Using wordlist: {Configuration.wordlist}')
+            wordlists_to_try = [wl for wl in Configuration.wordlists if os.path.exists(wl)]
+            if not wordlists_to_try:
+                wordlists_to_try = [Configuration.wordlist]
+
+            log_info('AttackPMKID', f'Using {len(wordlists_to_try)} wordlist(s)')
             if self.view:
                 self.view.set_attack_type("PMKID Crack")
-                self.view.add_log(f"Starting PMKID crack with wordlist: {Configuration.wordlist}")
+                self.view.add_log(f"Starting PMKID crack with {len(wordlists_to_try)} wordlist(s)")
                 self.view.add_log("Running hashcat...")
 
-            Color.clear_entire_line()
-            Color.pattack('PMKID', self.target, 'CRACK', 'Cracking PMKID using {C}%s{W} ...\n' % Configuration.wordlist)
-            key = Hashcat.crack_pmkid(pmkid_file)
+            key = None
+            for wordlist in wordlists_to_try:
+                wordlist_name = os.path.basename(wordlist)
+                Color.clear_entire_line()
+                Color.pattack('PMKID', self.target, 'CRACK', 'Cracking PMKID using {C}%s{W} ...\n' % wordlist_name)
+                key = Hashcat.crack_pmkid(pmkid_file, wordlist=wordlist)
+                if key is not None:
+                    break
+                Color.pl('{!} {O}%s did not contain password{W}' % wordlist_name)
 
         if key is not None:
             log_info('AttackPMKID', f'PMKID cracked successfully! Password: {mask_sensitive(key)}')

--- a/wifite/attack/pmkid_passive.py
+++ b/wifite/attack/pmkid_passive.py
@@ -545,35 +545,43 @@ class AttackPassivePMKID:
         
         if not Configuration.wordlist:
             Color.pl('{!} {O}No wordlist specified, skipping crack{W}')
-            Color.pl('{!} {O}Use {C}--dict{O} to specify a wordlist{W}')
+            Color.pl('{!} {O}Use {C}--dict{O} to specify a wordlist or directory{W}')
             return
-        
+
+        wordlists_to_try = [wl for wl in Configuration.wordlists if os.path.exists(wl)]
+        if not wordlists_to_try:
+            wordlists_to_try = [Configuration.wordlist]
+
         cracked_count = 0
-        
+
         for bssid, pmkid_data in self.captured_pmkids.items():
             essid = pmkid_data['essid']
             pmkid_file = pmkid_data['file']
-            
+
             Color.pl('')
             Color.pl('{+} {C}Cracking PMKID for:{W} {G}%s{W} ({C}%s{W})' % (
                 essid if essid else '<hidden>',
                 bssid
             ))
-            
-            # Attempt to crack
-            key = Hashcat.crack_pmkid(pmkid_file, verbose=Configuration.verbose > 0)
-            
+
+            # Attempt to crack with each wordlist
+            key = None
+            for wordlist in wordlists_to_try:
+                key = Hashcat.crack_pmkid(pmkid_file, verbose=Configuration.verbose > 0, wordlist=wordlist)
+                if key:
+                    break
+
             if key:
                 cracked_count += 1
                 Color.pl('{+} {G}SUCCESS!{W} Password: {G}%s{W}' % key)
-                
+
                 # Save result
                 from ..model.pmkid_result import CrackResultPMKID
                 result = CrackResultPMKID(bssid, essid, pmkid_file, key)
                 result.save()
                 result.dump()
             else:
-                Color.pl('{!} {R}Failed to crack{W} (password not in wordlist)')
+                Color.pl('{!} {R}Failed to crack{W} (password not in any wordlist)')
         
         Color.pl('')
         Color.pl('{+} {C}Cracking complete:{W} {G}%d{W}/{G}%d{W} PMKIDs cracked' % (

--- a/wifite/attack/wpa.py
+++ b/wifite/attack/wpa.py
@@ -368,8 +368,11 @@ class AttackWPA(Attack):
             return self._handle_attack_failure(
                 '{!} {O}Not cracking handshake because wordlist ({R}--dict{O}) is not set'
             )
-        elif not os.path.exists(Configuration.wordlist):
-            Color.pl('{!} {O}Not cracking handshake because wordlist {R}%s{O} was not found' % Configuration.wordlist)
+
+        # Get list of wordlists to try
+        wordlists_to_try = [wl for wl in Configuration.wordlists if os.path.exists(wl)]
+        if not wordlists_to_try:
+            Color.pl('{!} {O}Not cracking handshake because no valid wordlist files were found')
             self.success = False
             return False
 
@@ -384,34 +387,41 @@ class AttackWPA(Attack):
         # as Hashcat mode 22000 (hccapx) is generally preferred over aircrack-ng.
         # Aircrack.crack_handshake might be removed or kept for WEP only in future.
 
-        wordlist_name = os.path.split(Configuration.wordlist)[-1] if Configuration.wordlist else "default wordlist"
-        crack_msg = f'Cracking {"WPA3-SAE" if target_is_wpa3_sae else "WPA/WPA2"} Handshake: Running {cracker} with {wordlist_name} wordlist'
-        
-        Color.pl(f'\n{{+}} {{C}}{crack_msg}{{W}}')
-        
-        # Update TUI view if available
-        if self.view:
-            self.view.add_log(crack_msg)
-            self.view.update_progress({
-                'status': f'Cracking with {cracker}...',
-                'metrics': {
-                    'Cracker': cracker,
-                    'Wordlist': wordlist_name,
-                    'Type': 'WPA3-SAE' if target_is_wpa3_sae else 'WPA/WPA2'
-                }
-            })
+        key = None
+        for idx, wordlist in enumerate(wordlists_to_try):
+            wordlist_name = os.path.split(wordlist)[-1]
+            crack_msg = f'Cracking {"WPA3-SAE" if target_is_wpa3_sae else "WPA/WPA2"} Handshake: Running {cracker} with {wordlist_name} wordlist ({idx + 1}/{len(wordlists_to_try)})'
 
-        try:
-            key = Hashcat.crack_handshake(handshake, target_is_wpa3_sae, show_command=Configuration.verbose > 1)
-        except ValueError as e: # Catch errors from hash file generation (e.g. bad capture)
-            error_msg = f"Error during hash file generation for cracking: {e}"
-            Color.pl(f"[!] {error_msg}")
+            Color.pl(f'\n{{+}} {{C}}{crack_msg}{{W}}')
+
+            # Update TUI view if available
             if self.view:
-                self.view.add_log(error_msg)
-            key = None
+                self.view.add_log(crack_msg)
+                self.view.update_progress({
+                    'status': f'Cracking with {cracker}...',
+                    'metrics': {
+                        'Cracker': cracker,
+                        'Wordlist': wordlist_name,
+                        'Type': 'WPA3-SAE' if target_is_wpa3_sae else 'WPA/WPA2'
+                    }
+                })
+
+            try:
+                key = Hashcat.crack_handshake(handshake, target_is_wpa3_sae, show_command=Configuration.verbose > 1, wordlist=wordlist)
+            except ValueError as e: # Catch errors from hash file generation (e.g. bad capture)
+                error_msg = f"Error during hash file generation for cracking: {e}"
+                Color.pl(f"[!] {error_msg}")
+                if self.view:
+                    self.view.add_log(error_msg)
+                key = None
+
+            if key is not None:
+                break
+
+            Color.pl(f'{{!}} {{O}}{wordlist_name} did not contain password{{W}}')
 
         if key is None:
-            fail_msg = f"Failed to crack handshake: {wordlist_name} did not contain password"
+            fail_msg = 'Failed to crack handshake: password not found in any wordlist'
             Color.pl(f"{{!}} {{R}}{fail_msg}{{W}}")
             if self.view:
                 self.view.add_log(fail_msg)

--- a/wifite/config.py
+++ b/wifite/config.py
@@ -84,6 +84,7 @@ class Configuration:
     wep_restart_aircrack = None
     wep_restart_stale_ivs = None
     wordlist = None
+    wordlists = []
     wpa_attack_timeout = None
     wpa_deauth_timeout = None
     wpa_filter = None
@@ -232,7 +233,8 @@ class Configuration:
         # Default dictionary for cracking
         cls.cracked_file = 'cracked.json'
         cls.wordlist = None
-        wordlists = [
+        cls.wordlists = []
+        default_wordlists = [
             './wordlist-probable.txt',  # Local file (ran from cloned repo)
             '/usr/share/dict/wordlist-probable.txt',  # setup.py with prefix=/usr
             '/usr/local/share/dict/wordlist-probable.txt',  # setup.py with prefix=/usr/local
@@ -241,9 +243,10 @@ class Configuration:
             '/usr/share/fuzzdb/wordlists-user-passwd/passwds/phpbb.txt',
             '/usr/share/wordlists/fern-wifi/common.txt'
         ]
-        for wlist in wordlists:
+        for wlist in default_wordlists:
             if os.path.exists(wlist):
                 cls.wordlist = wlist
+                cls.wordlists = [wlist]
                 break
 
         if os.path.isfile('/usr/share/ieee-data/oui.txt'):
@@ -771,15 +774,31 @@ class Configuration:
         if args.wordlist:
             if not os.path.exists(args.wordlist):
                 cls.wordlist = None
+                cls.wordlists = []
                 Color.pl('{+} {C}option:{O} wordlist {R}%s{O} was not found, wifite will NOT attempt to crack '
                          'handshakes' % args.wordlist)
             elif os.path.isfile(args.wordlist):
                 cls.wordlist = args.wordlist
+                cls.wordlists = [args.wordlist]
                 Color.pl('{+} {C}option:{W} using wordlist {G}%s{W} for cracking' % args.wordlist)
             elif os.path.isdir(args.wordlist):
-                cls.wordlist = None
-                Color.pl('{+} {C}option:{O} wordlist {R}%s{O} is a directory, not a file. Wifite will NOT attempt to '
-                         'crack handshakes' % args.wordlist)
+                # Collect all files in the directory as wordlists
+                dict_dir = args.wordlist
+                files = sorted([
+                    os.path.join(dict_dir, f)
+                    for f in os.listdir(dict_dir)
+                    if os.path.isfile(os.path.join(dict_dir, f))
+                ])
+                if files:
+                    cls.wordlists = files
+                    cls.wordlist = files[0]
+                    Color.pl('{+} {C}option:{W} using {G}%d{W} wordlist(s) from directory {G}%s{W} for cracking'
+                             % (len(files), dict_dir))
+                else:
+                    cls.wordlist = None
+                    cls.wordlists = []
+                    Color.pl('{+} {C}option:{O} wordlist directory {R}%s{O} contains no files. Wifite will NOT '
+                             'attempt to crack handshakes' % dict_dir)
 
         if args.wpa_deauth_timeout:
             cls.wpa_deauth_timeout = args.wpa_deauth_timeout

--- a/wifite/tools/aircrack.py
+++ b/wifite/tools/aircrack.py
@@ -81,16 +81,17 @@ class Aircrack(Dependency):
             os.remove(self.cracked_file)
 
     @staticmethod
-    def crack_handshake(handshake, show_command=False):
+    def crack_handshake(handshake, show_command=False, wordlist=None):
         from ..util.color import Color
         from ..util.timer import Timer
         '''Tries to crack a handshake. Returns WPA key if found, otherwise None.'''
 
+        wordlist = wordlist or Configuration.wordlist
         key_file = Configuration.temp('wpakey.txt')
         command = [
             'aircrack-ng',
             '-a', '2',
-            '-w', Configuration.wordlist,
+            '-w', wordlist,
             '--bssid', handshake.bssid,
             '-l', key_file,
             handshake.capfile

--- a/wifite/tools/cowpatty.py
+++ b/wifite/tools/cowpatty.py
@@ -14,11 +14,11 @@ class Cowpatty(Dependency):
     dependency_url = 'https://tools.kali.org/wireless-attacks/cowpatty'
 
     @staticmethod
-    def crack_handshake(handshake, show_command=False):
-        # Crack john file
+    def crack_handshake(handshake, show_command=False, wordlist=None):
+        wordlist = wordlist or Configuration.wordlist
         command = [
             'cowpatty',
-            '-f', Configuration.wordlist,
+            '-f', wordlist,
             '-r', handshake.capfile,
             '-s', handshake.essid
         ]

--- a/wifite/tools/hashcat.py
+++ b/wifite/tools/hashcat.py
@@ -23,11 +23,12 @@ class Hashcat(Dependency):
         return 'No devices found/left' in stderr or 'Unstable OpenCL driver detected!' in stderr
 
     @staticmethod
-    def crack_handshake(handshake_obj, target_is_wpa3_sae, show_command=False):
+    def crack_handshake(handshake_obj, target_is_wpa3_sae, show_command=False, wordlist=None):
         """
         Cracks a handshake.
         handshake_obj: A Handshake object (should have .capfile attribute)
         target_is_wpa3_sae: Boolean indicating if the target uses WPA3-SAE
+        wordlist: Path to wordlist file (uses Configuration.wordlist if None)
         """
         hash_file = HcxPcapngTool.generate_hash_file(handshake_obj, target_is_wpa3_sae, show_command=show_command)
 
@@ -35,8 +36,9 @@ class Hashcat(Dependency):
         if hash_file is None:
             Color.pl('{!} {O}Falling back to aircrack-ng for cracking{W}')
             from .aircrack import Aircrack
-            return Aircrack.crack_handshake(handshake_obj, show_command=show_command)
+            return Aircrack.crack_handshake(handshake_obj, show_command=show_command, wordlist=wordlist)
 
+        wordlist = wordlist or Configuration.wordlist
         key = None
         try:
             # Mode 22000 supports both WPA/WPA2 and WPA3-SAE (WPA-PBKDF2-PMKID+EAPOL)
@@ -52,7 +54,7 @@ class Hashcat(Dependency):
                     '--quiet',
                     '-m', hashcat_mode,
                     hash_file,
-                    Configuration.wordlist
+                    wordlist
                 ]
                 if Hashcat.should_use_force():
                     command.append('--force')
@@ -97,12 +99,13 @@ class Hashcat(Dependency):
                         Color.pl('{!} {O}Warning: Could not remove hash file: %s{W}' % str(e))
 
     @staticmethod
-    def crack_pmkid(pmkid_file, verbose=False):
+    def crack_pmkid(pmkid_file, verbose=False, wordlist=None):
         """
         Cracks a given pmkid_file using the PMKID/WPA2 attack (-m 22000)
         Returns:
             Key (str) if found; `None` if not found.
         """
+        wordlist = wordlist or Configuration.wordlist
 
         # Run hashcat once normally, then with --show if it failed
         # To catch cases where the password is already in the pot file.
@@ -113,7 +116,7 @@ class Hashcat(Dependency):
                 '-m', '22000',  # WPA-PMKID-PBKDF2
                 '-a', '0',      # Wordlist attack-mode
                 pmkid_file,
-                Configuration.wordlist,
+                wordlist,
                 '-w', '3'
             ]
             if Hashcat.should_use_force():

--- a/wifite/tools/john.py
+++ b/wifite/tools/john.py
@@ -17,9 +17,10 @@ class John(Dependency):
     dependency_url = 'https://www.openwall.com/john/'
 
     @staticmethod
-    def crack_handshake(handshake, show_command=False):
+    def crack_handshake(handshake, show_command=False, wordlist=None):
         john_file = HcxPcapngTool.generate_john_file(handshake, show_command=show_command)
 
+        wordlist = wordlist or Configuration.wordlist
         key = None
         try:
             # Use `john --list=formats` to find if OpenCL or CUDA is supported.
@@ -32,7 +33,7 @@ class John(Dependency):
                 john_format = 'wpapsk'
 
             # Crack john file
-            command = ['john', f'--format={john_format}', f'--wordlist={Configuration.wordlist}', john_file]
+            command = ['john', f'--format={john_format}', f'--wordlist={wordlist}', john_file]
             if show_command:
                 Color.pl('{+} {D}Running: {W}{P}%s{W}' % ' '.join(command))
             process = Process(command)

--- a/wifite/util/crack.py
+++ b/wifite/util/crack.py
@@ -104,13 +104,29 @@ class CrackHelper:
 
         # Get wordlist
         if not Configuration.wordlist:
-            Color.p('\n{+} Enter wordlist file to use for cracking: {G}')
-            Configuration.wordlist = input()
+            Color.p('\n{+} Enter wordlist file or directory to use for cracking: {G}')
+            user_input = input()
             Color.p('{W}')
 
-            if not os.path.exists(Configuration.wordlist):
-                Color.pl('{!} {R}Wordlist {O}%s{R} not found. Exiting.' % Configuration.wordlist)
+            if not os.path.exists(user_input):
+                Color.pl('{!} {R}Wordlist {O}%s{R} not found. Exiting.' % user_input)
                 return
+
+            if os.path.isdir(user_input):
+                files = sorted([
+                    os.path.join(user_input, f)
+                    for f in os.listdir(user_input)
+                    if os.path.isfile(os.path.join(user_input, f))
+                ])
+                if not files:
+                    Color.pl('{!} {R}Directory {O}%s{R} contains no files. Exiting.' % user_input)
+                    return
+                Configuration.wordlists = files
+                Configuration.wordlist = files[0]
+                Color.pl('{+} Using {G}%d{W} wordlist(s) from directory {G}%s{W}' % (len(files), user_input))
+            else:
+                Configuration.wordlist = user_input
+                Configuration.wordlists = [user_input]
             Color.pl('')
 
         # Get handshakes
@@ -363,31 +379,41 @@ class CrackHelper:
             Color.pl('{!} {R}Error: {O}%s{W}' % e)
             return None
 
-        if tool == 'aircrack':
-            key = Aircrack.crack_handshake(handshake, show_command=True)
-        elif tool == 'hashcat':
-            key = Hashcat.crack_handshake(handshake, target_is_wpa3_sae=False, show_command=True)
-        elif tool == 'john':
-            key = John.crack_handshake(handshake, show_command=True)
-        elif tool == 'cowpatty':
-            key = Cowpatty.crack_handshake(handshake, show_command=True)
+        wordlists_to_try = Configuration.wordlists if Configuration.wordlists else [Configuration.wordlist]
 
-        if key is not None:
-            return CrackResultWPA(hs['bssid'], hs['essid'], hs['filename'], key)
-        else:
-            return None
+        for wordlist in wordlists_to_try:
+            wordlist_name = os.path.basename(wordlist)
+            Color.pl('{+} Trying wordlist: {C}%s{W}' % wordlist_name)
+
+            if tool == 'aircrack':
+                key = Aircrack.crack_handshake(handshake, show_command=True, wordlist=wordlist)
+            elif tool == 'hashcat':
+                key = Hashcat.crack_handshake(handshake, target_is_wpa3_sae=False, show_command=True, wordlist=wordlist)
+            elif tool == 'john':
+                key = John.crack_handshake(handshake, show_command=True, wordlist=wordlist)
+            elif tool == 'cowpatty':
+                key = Cowpatty.crack_handshake(handshake, show_command=True, wordlist=wordlist)
+
+            if key is not None:
+                return CrackResultWPA(hs['bssid'], hs['essid'], hs['filename'], key)
+
+        return None
 
     @classmethod
     def crack_pmkid(cls, hs, tool):
         if tool != 'hashcat':
             Color.pl('{!} {O}Note: PMKID hashes can only be cracked using {C}hashcat{W}')
 
-        key2 = Hashcat.crack_pmkid(hs['filename'], verbose=True)
+        wordlists_to_try = Configuration.wordlists if Configuration.wordlists else [Configuration.wordlist]
 
-        if key2 is not None:
-            return CrackResultPMKID(hs['bssid'], hs['essid'], hs['filename'], key2)
-        else:
-            return None
+        for wordlist in wordlists_to_try:
+            wordlist_name = os.path.basename(wordlist)
+            Color.pl('{+} Trying wordlist: {C}%s{W}' % wordlist_name)
+            key2 = Hashcat.crack_pmkid(hs['filename'], verbose=True, wordlist=wordlist)
+            if key2 is not None:
+                return CrackResultPMKID(hs['bssid'], hs['essid'], hs['filename'], key2)
+
+        return None
 
     @classmethod
     def crack_sae(cls, hs, tool):
@@ -395,26 +421,29 @@ class CrackHelper:
         if tool != 'hashcat':
             Color.pl('{!} {O}Note: WPA3-SAE handshakes can only be cracked using {C}hashcat{W}')
             return None
-        
+
         # Create SAEHandshake object
         sae_handshake = SAEHandshake(
             capfile=hs['filename'],
             bssid=hs['bssid'],
             essid=hs['essid']
         )
-        
-        # Crack using SAECracker
-        key = SAECracker.crack_sae_handshake(
-            sae_handshake,
-            wordlist=Configuration.wordlist,
-            show_command=True,
-            verbose=True
-        )
-        
-        if key is not None:
-            return CrackResultSAE(hs['bssid'], hs['essid'], hs['filename'], key)
-        else:
-            return None
+
+        wordlists_to_try = Configuration.wordlists if Configuration.wordlists else [Configuration.wordlist]
+
+        for wordlist in wordlists_to_try:
+            wordlist_name = os.path.basename(wordlist)
+            Color.pl('{+} Trying wordlist: {C}%s{W}' % wordlist_name)
+            key = SAECracker.crack_sae_handshake(
+                sae_handshake,
+                wordlist=wordlist,
+                show_command=True,
+                verbose=True
+            )
+            if key is not None:
+                return CrackResultSAE(hs['bssid'], hs['essid'], hs['filename'], key)
+
+        return None
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When --dict is given a directory path instead of a file, wifite now collects all files in the directory and uses them as wordlists for cracking. Each wordlist is tried sequentially until a password is found or all wordlists are exhausted.

Changes:
- config.py: Add wordlists list, handle directory paths in --dict
- args.py: Update help text to indicate file/directory support
- tools: Add optional wordlist parameter to all cracking tools (hashcat, aircrack, john, cowpatty)
- attacks: Iterate through multiple wordlists in WPA, PMKID, and PMKID passive attacks
- util/crack.py: Support directory input in manual crack mode