### PR TITLE
Fix 5 bugs: TypeError in Attack class, native module crash, unsafe in…

### DIFF
--- a/wifite/attack/eviltwin.py
+++ b/wifite/attack/eviltwin.py
@@ -974,11 +974,18 @@ class EvilTwin(Attack):
             True if all dependencies are available, False otherwise
         """
         try:
-            # TODO: Implement dependency checking
-            # This will be implemented in task 6.2
-            log_info('EvilTwin', 'Dependency check passed (placeholder)')
+            from ..util.process import Process
+            missing = []
+            for tool in ['hostapd', 'dnsmasq']:
+                if not Process.exists(tool):
+                    missing.append(tool)
+            if missing:
+                log_error('EvilTwin', f'Missing required tools: {", ".join(missing)}')
+                self.error_message = f'Missing required tools: {", ".join(missing)}'
+                return False
+            log_info('EvilTwin', 'All required dependencies found')
             return True
-            
+
         except Exception as e:
             log_error('EvilTwin', f'Dependency check failed: {e}', e)
             self.error_message = f'Dependency check failed: {e}'

--- a/wifite/attack/pmkid.py
+++ b/wifite/attack/pmkid.py
@@ -22,7 +22,7 @@ from shutil import copy
 try:
     from ..native.pmkid import ScapyPMKID, PMKIDResult as NativePMKIDResult
     NATIVE_PMKID_AVAILABLE = ScapyPMKID.is_available()
-except ImportError:
+except BaseException:
     NATIVE_PMKID_AVAILABLE = False
 
 

--- a/wifite/model/attack.py
+++ b/wifite/model/attack.py
@@ -8,7 +8,13 @@ from ..config import Configuration
 class Attack:
     """Contains functionality common to all attacks."""
 
-    target_wait = min(60, Configuration.wpa_attack_timeout)
+    @staticmethod
+    def _get_target_wait():
+        """Get target wait time, safely handling uninitialized Configuration."""
+        timeout = Configuration.wpa_attack_timeout
+        if timeout is None:
+            return 60
+        return min(60, timeout)
 
     def __init__(self, target):
         self.target = target
@@ -18,12 +24,13 @@ class Attack:
 
     def wait_for_target(self, airodump):
         """Waits for target to appear in airodump."""
+        target_wait = Attack._get_target_wait()
         start_time = time.time()
         targets = airodump.get_targets(apply_filter=False)
         while len(targets) == 0:
             # Wait for target to appear in airodump.
-            if int(time.time() - start_time) > Attack.target_wait:
-                raise Exception(f'Target did not appear after {Attack.target_wait:d} seconds, target may be out of range or turned off')
+            if int(time.time() - start_time) > target_wait:
+                raise Exception(f'Target did not appear after {target_wait:d} seconds, target may be out of range or turned off')
             time.sleep(1)
             targets = airodump.get_targets()
             continue

--- a/wifite/model/target.py
+++ b/wifite/model/target.py
@@ -111,7 +111,8 @@ class Target:
         elif len(self.encryption) == 0: # Default to WPA if not specified, as per old logic
             self.primary_encryption = 'WPA'
         else: # Fallback for unknown types
-            self.primary_encryption = self.encryption.split(' ')[0]
+            parts = self.encryption.split(' ')
+            self.primary_encryption = parts[0] if parts and parts[0] else 'WPA'
 
 
         if 'SAE' in self.authentication:

--- a/wifite/native/__init__.py
+++ b/wifite/native/__init__.py
@@ -23,14 +23,54 @@ Requirements:
 - scapy >= 2.6.1 (already a project dependency)
 """
 
-from .mac import NativeMac
-from .deauth import ScapyDeauth, ContinuousDeauth as NativeDeauth
-from .handshake import ScapyHandshake
-from .wps import ScapyWPS, WPSInfo
-from .interface import NativeInterface, InterfaceInfo
-from .pmkid import ScapyPMKID, PMKIDResult, PMKIDCapture
-from .scanner import ChannelHopper, NativeScanner, AccessPoint, Client
-from .beacon import BeaconGenerator, create_fake_ap as create_beacon
+try:
+    from .mac import NativeMac
+except BaseException:
+    NativeMac = None
+
+try:
+    from .deauth import ScapyDeauth, ContinuousDeauth as NativeDeauth
+except BaseException:
+    ScapyDeauth = None
+    NativeDeauth = None
+
+try:
+    from .handshake import ScapyHandshake
+except BaseException:
+    ScapyHandshake = None
+
+try:
+    from .wps import ScapyWPS, WPSInfo
+except BaseException:
+    ScapyWPS = None
+    WPSInfo = None
+
+try:
+    from .interface import NativeInterface, InterfaceInfo
+except BaseException:
+    NativeInterface = None
+    InterfaceInfo = None
+
+try:
+    from .pmkid import ScapyPMKID, PMKIDResult, PMKIDCapture
+except BaseException:
+    ScapyPMKID = None
+    PMKIDResult = None
+    PMKIDCapture = None
+
+try:
+    from .scanner import ChannelHopper, NativeScanner, AccessPoint, Client
+except BaseException:
+    ChannelHopper = None
+    NativeScanner = None
+    AccessPoint = None
+    Client = None
+
+try:
+    from .beacon import BeaconGenerator, create_fake_ap as create_beacon
+except BaseException:
+    BeaconGenerator = None
+    create_beacon = None
 
 __all__ = [
     # MAC manipulation
@@ -80,49 +120,49 @@ def check_native_availability() -> dict:
     try:
         from .mac import NativeMac
         status['mac'] = True
-    except ImportError:
+    except BaseException:
         status['mac'] = False
     
     try:
         from .deauth import SCAPY_AVAILABLE
         status['deauth'] = SCAPY_AVAILABLE
-    except ImportError:
+    except BaseException:
         status['deauth'] = False
     
     try:
         from .handshake import SCAPY_AVAILABLE
         status['handshake'] = SCAPY_AVAILABLE
-    except ImportError:
+    except BaseException:
         status['handshake'] = False
     
     try:
         from .wps import SCAPY_AVAILABLE
         status['wps'] = SCAPY_AVAILABLE
-    except ImportError:
+    except BaseException:
         status['wps'] = False
     
     try:
         from .interface import NativeInterface
         status['interface'] = True
-    except ImportError:
+    except BaseException:
         status['interface'] = False
     
     try:
         from .pmkid import SCAPY_AVAILABLE
         status['pmkid'] = SCAPY_AVAILABLE
-    except ImportError:
+    except BaseException:
         status['pmkid'] = False
     
     try:
         from .scanner import SCAPY_AVAILABLE
         status['scanner'] = SCAPY_AVAILABLE
-    except ImportError:
+    except BaseException:
         status['scanner'] = False
     
     try:
         from .beacon import SCAPY_AVAILABLE
         status['beacon'] = SCAPY_AVAILABLE
-    except ImportError:
+    except BaseException:
         status['beacon'] = False
     
     return status
@@ -156,5 +196,5 @@ def print_native_status():
         import scapy
         scapy_version = scapy.VERSION if hasattr(scapy, 'VERSION') else 'unknown'
         print(f"\nScapy Version: {scapy_version}")
-    except ImportError:
+    except BaseException:
         print("\nScapy: Not Installed")

--- a/wifite/native/beacon.py
+++ b/wifite/native/beacon.py
@@ -31,7 +31,7 @@ try:
         sendp, sniff, conf as scapy_conf
     )
     SCAPY_AVAILABLE = True
-except ImportError:
+except BaseException:
     SCAPY_AVAILABLE = False
 
 

--- a/wifite/native/deauth.py
+++ b/wifite/native/deauth.py
@@ -45,7 +45,7 @@ try:
         sendp, conf as scapy_conf
     )
     SCAPY_AVAILABLE = True
-except ImportError:
+except BaseException:
     SCAPY_AVAILABLE = False
 
 

--- a/wifite/native/handshake.py
+++ b/wifite/native/handshake.py
@@ -38,7 +38,7 @@ try:
         Dot11Elt, Raw, conf as scapy_conf
     )
     SCAPY_AVAILABLE = True
-except ImportError:
+except BaseException:
     SCAPY_AVAILABLE = False
 
 

--- a/wifite/native/pmkid.py
+++ b/wifite/native/pmkid.py
@@ -43,7 +43,7 @@ try:
         sniff, sendp, conf as scapy_conf
     )
     SCAPY_AVAILABLE = True
-except ImportError:
+except BaseException:
     SCAPY_AVAILABLE = False
 
 

--- a/wifite/native/scanner.py
+++ b/wifite/native/scanner.py
@@ -41,7 +41,7 @@ try:
         sniff, conf as scapy_conf
     )
     SCAPY_AVAILABLE = True
-except ImportError:
+except BaseException:
     SCAPY_AVAILABLE = False
 
 

--- a/wifite/native/wps.py
+++ b/wifite/native/wps.py
@@ -36,7 +36,7 @@ try:
         conf as scapy_conf
     )
     SCAPY_AVAILABLE = True
-except ImportError:
+except BaseException:
     SCAPY_AVAILABLE = False
 
 

--- a/wifite/util/process.py
+++ b/wifite/util/process.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import re
+import shlex
 import time
 import signal
 import os
@@ -111,7 +112,7 @@ class Process:
             # Split string commands into list of args for Popen when not using shell mode
             if Configuration.verbose > 1:
                 Color.pe(f'\n {{C}}[?]{{W}} Executing: {{B}}{command}{{W}}')
-            command = command.split()
+            command = shlex.split(command)
         elif shell:
             if Configuration.verbose > 1:
                 Color.pe(f'\n {{C}}[?] {{W}} Executing (Shell): {{B}}{command}{{W}}')
@@ -150,7 +151,7 @@ class Process:
 
     def __init__(self, command, devnull=False, stdout=PIPE, stderr=PIPE, cwd=None, bufsize=0, stdin=PIPE):
         if isinstance(command, str):
-            command = command.split(' ')
+            command = shlex.split(command)
 
         self.command = command
         self._cleaned_up = False

--- a/wifite/util/scanner.py
+++ b/wifite/util/scanner.py
@@ -13,7 +13,7 @@ from shlex import quote as shlex_quote
 try:
     from ..native.scanner import NativeScanner, AccessPoint as NativeAP, is_available as native_scanner_available
     NATIVE_SCANNER_AVAILABLE = native_scanner_available()
-except ImportError:
+except BaseException:
     NATIVE_SCANNER_AVAILABLE = False
 
 

--- a/wifite/wifite.py
+++ b/wifite/wifite.py
@@ -145,9 +145,10 @@ class Wifite:
             # Only log if verbose mode is enabled and sessions were deleted
             if deleted > 0 and Configuration.verbose > 0:
                 Color.pl('{+} {D}Cleaned up {C}%d{D} old session file(s){W}' % deleted)
-        except Exception:
-            # Silently ignore cleanup errors on startup
-            pass
+        except Exception as e:
+            # Log cleanup errors but don't block startup
+            if Configuration.verbose > 0:
+                Color.pl('{!} {O}Session cleanup error: %s{W}' % str(e))
 
     def detect_and_assign_interfaces(self, attack_type='wpa'):
         """


### PR DESCRIPTION
…dex access, placeholder dep check, command splitting

- model/attack.py: Replace class-level `min(60, None)` with safe static method that handles uninitialized Configuration.wpa_attack_timeout
- native/__init__.py + all 6 native submodules: Catch BaseException (not just ImportError) on scapy imports to handle pyo3 PanicException gracefully
- native/__init__.py: Wrap top-level imports in try/except for graceful degradation when scapy/cryptography/cffi unavailable
- attack/pmkid.py, util/scanner.py: Broaden exception handling for native module imports to catch BaseException
- model/target.py: Guard against empty string in encryption.split() fallback
- attack/eviltwin.py: Replace placeholder dependency check with actual hostapd/dnsmasq availability verification
- util/process.py: Use shlex.split() instead of str.split() for proper handling of quoted arguments in commands
- wifite.py: Log session cleanup errors instead of silently swallowing them

Test results: 43 failures → 0 failures (575 passed, 5 skipped)