### PR TITLE
Add --ignore-captured flag

### DIFF
--- a/wifite/args.py
+++ b/wifite/args.py
@@ -373,6 +373,11 @@ against the real AP and captures valid passwords.
                           dest='ignore_cracked',
                           help=Color.s('Hides previously-cracked targets. (default: {G}off{W})'))
 
+        glob.add_argument('--ignore-captured',
+                          action='store_true',
+                          dest='ignore_captured',
+                          help=Color.s('Hides targets with existing captured handshakes/pmkid. (default: {G}off{W})'))
+
         glob.add_argument('--clients-only',
                           action='store_true',
                           dest='clients_only',

--- a/wifite/config.py
+++ b/wifite/config.py
@@ -34,6 +34,7 @@ class Configuration:
     encryption_filter = None
     existing_commands = None
     five_ghz = None
+    ignore_captured = None
     ignore_cracked = None
     ignore_essids = None
     ignore_old_handshakes = None
@@ -204,6 +205,7 @@ class Configuration:
         cls.target_essid = None  # User-defined AP name
         cls.target_bssid = None  # User-defined AP BSSID
         cls.ignore_essids = None  # ESSIDs to ignore
+        cls.ignore_captured = False  # Ignore targets with existing captures
         cls.ignore_cracked = False  # Ignore previously-cracked BSSIDs
         cls.clients_only = False  # Only show targets that have associated clients
         cls.all_bands = False  # Scan for both 2Ghz and 5Ghz channels
@@ -729,6 +731,15 @@ class Configuration:
             else:
                 Color.pl('{!} {R}Previously-cracked access points not found in %s' % cls.cracked_file)
                 cls.ignore_cracked = False
+
+        if args.ignore_captured:
+            captured_bssids = CrackResult.load_captured_bssids(cls.wpa_handshake_dir)
+            if captured_bssids:
+                cls.ignore_captured = captured_bssids
+                Color.pl('{+} {C}option: {O}ignoring {R}%s{O} targets with existing captures' % len(captured_bssids))
+            else:
+                Color.pl('{!} {R}No captured handshakes/PMKIDs found in %s' % cls.wpa_handshake_dir)
+
         if args.clients_only:
             cls.clients_only = True
             Color.pl('{+} {C}option:{W} {O}ignoring targets that do not have associated clients')

--- a/wifite/model/result.py
+++ b/wifite/model/result.py
@@ -4,7 +4,9 @@
 from ..util.color import Color
 from ..config import Configuration
 
+import glob
 import os
+import re
 import time
 from json import loads, dumps
 
@@ -145,6 +147,21 @@ class CrackResult:
             for item in json
             if item.get('type') != 'IGN'
         ]
+
+    @classmethod
+    def load_captured_bssids(cls, hs_dir):
+        """Scan hs_dir for captured handshake/PMKID files and return list of BSSIDs."""
+        bssids = set()
+        if not os.path.isdir(hs_dir):
+            return []
+
+        bssid_re = re.compile(r'^(?:handshake|pmkid)_.+_([0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2})_', re.IGNORECASE)
+        for fname in os.listdir(hs_dir):
+            m = bssid_re.match(fname)
+            if m:
+                bssids.add(m.group(1).replace('-', ':').upper())
+
+        return list(bssids)
 
     @staticmethod
     def load(json):

--- a/wifite/tools/airodump.py
+++ b/wifite/tools/airodump.py
@@ -404,6 +404,9 @@ class Airodump(Dependency):
             elif Configuration.ignore_cracked and \
                     result[i].bssid in Configuration.ignore_cracked:
                 result.pop(i)
+            elif Configuration.ignore_captured and \
+                    result[i].bssid in Configuration.ignore_captured:
+                result.pop(i)
             elif bssid and result[i].bssid.lower() != bssid.lower():
                 result.pop(i)
             elif essid and result[i].essid and result[i].essid != essid:


### PR DESCRIPTION
## Summary
- Adds `--ignore-captured` CLI flag that hides targets which already have a captured handshake (`.cap`) or PMKID (`.22000`) file in the `hs/` directory
- Follows the same pattern as the existing `--ignore-cracked` flag
- Useful when re-running wifite to only capture new targets

## Changes
- `wifite/args.py` — new `--ignore-captured` argument
- `wifite/config.py` — config variable + initialization logic
- `wifite/model/result.py` — `load_captured_bssids()` classmethod to scan `hs/` for existing capture files
- `wifite/tools/airodump.py` — filter matching BSSIDs from scan results

## Test plan
- [ ] Run `--help` and confirm `--ignore-captured` appears
- [ ] Place a test `.cap` or `.22000` file in `hs/` with a known BSSID, run with `--ignore-captured`, verify that BSSID is filtered from scan results
- [ ] Run without `--ignore-captured` and verify no filtering occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)