### PR TITLE
Fix: Corrected color formatting in interface status output

### DIFF
--- a/wifite/util/system_check.py
+++ b/wifite/util/system_check.py
@@ -716,7 +716,7 @@ class SystemCheck:
                 else:
                     masked = iface.mac
                 Color.pl(f'    MAC: {masked}   Mode: {{C}}{iface.mode}{{W}}   '
-                         f'Up: {"{{G}}yes{{W}}" if iface.is_up else "{{O}}no{{W}}"}')
+                         f'Up: {"{G}yes{W}" if iface.is_up else "{O}no{W}"}')
 
             # Capability matrix
             mon = '{G}✓{W}' if iface.supports_monitor else '{R}✗{W}'


### PR DESCRIPTION
Issue:
The interface status line was displaying literal curly braces around the "Up" status (e.g., Up: {}no{}) instead of applying the intended colors.

Cause:
The issue was caused by an f-string escaping conflict. Inside the f-string's expression block (the inline if/else), double curly braces {{O}} were being treated as literal characters rather than being unescaped. This resulted in the Color.pl method receiving {{O}}no{{W}} and failing to parse the color codes correctly, leaving the outer braces visible in the terminal.

Changes:

Removed unnecessary double braces inside the f-string's conditional logic for the iface.is_up check.

Verified that the status now correctly displays as colored text (Green "yes" / Orange "no") without visible brackets.

Before: 
<img width="735" height="122" alt="before" src="https://github.com/user-attachments/assets/4a24acd5-6c15-400d-9dad-f3f31c6f2d14" />

After:
<img width="745" height="140" alt="after" src="https://github.com/user-attachments/assets/b7a299c1-07e9-4726-b4bb-e39f4d1d0a61" />

