### PR TITLE
Docs: Update installation verification instructions to use --syscheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,16 @@ yay -S wifite2-git
 After installation, verify all dependencies are available:
 
 ```bash
-sudo wifite --help
+sudo wifite --syscheck
 ```
 
-This will show if any required tools are missing.
+This command provides a comprehensive report including:
 
+* **Environment:** Checks for root privileges, RF-Kill status, and conflicting processes.
+* **Tool Dependencies:** Verified list of required (Core) and optional tools.
+* **Wireless Interfaces:** Detection of adapters and their capabilities (Monitor mode, Injection).
+* **Attack Readiness:** A summary of which attacks (WPS, WPA3, PMKID, etc.) are possible with your current setup.
+* **Tip:** If you see "Conflicting processes found", it is highly recommended to run `airmon-ng check kill` or use the `--kill` flag when starting Wifite to ensure reliable performance.
 
 
 Features


### PR DESCRIPTION
Issue:
The current README.md suggests using sudo wifite --help to verify if dependencies are installed. However, the --help command only displays the help menu and does not perform any environment or dependency validation.

Solution:
Updated the "Verify Installation" section to recommend sudo wifite --syscheck. This is the correct command designed to perform a comprehensive system readiness assessment, including tool dependency checks, kernel environment verification, and interface capability matrix.

Changes:

Replaced sudo wifite --help with sudo wifite --syscheck in the verification steps.

Updated the description of what the command does to reflect the actual output (Environment, Tools, Interfaces, and Attack Readiness).