### PR TITLE
Fix: Improved tool version detection for Aircrack-ng suite and generic dependenciesBugfix/change version for air in syscheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,11 +196,16 @@ yay -S wifite2-git
 After installation, verify all dependencies are available:
 
 ```bash
-sudo wifite --help
+sudo wifite --syscheck
 ```
 
-This will show if any required tools are missing.
+This command provides a comprehensive report including:
 
+* **Environment:** Checks for root privileges, RF-Kill status, and conflicting processes.
+* **Tool Dependencies:** Verified list of required (Core) and optional tools.
+* **Wireless Interfaces:** Detection of adapters and their capabilities (Monitor mode, Injection).
+* **Attack Readiness:** A summary of which attacks (WPS, WPA3, PMKID, etc.) are possible with your current setup.
+* **Tip:** If you see "Conflicting processes found", it is highly recommended to run `airmon-ng check kill` or use the `--kill` flag when starting Wifite to ensure reliable performance.
 
 
 Features

--- a/wifite/util/system_check.py
+++ b/wifite/util/system_check.py
@@ -282,18 +282,33 @@ class SystemCheck:
 
     def _get_tool_version(self, name: str) -> Optional[str]:
         """Try to get version string for a tool."""
-        for flag in ['--version', '-v', '-V', 'version']:
+        if name.lower() == 'airmon-ng':
+            return None
+
+        for flag in ['--version', '-v', '-V', 'version', '']:
             try:
-                out = subprocess.run(
-                    [name, flag], capture_output=True, text=True, timeout=5
+                cmd = [name] + ([flag] if flag else [])
+                proc = subprocess.run(
+                    cmd, 
+                    capture_output=True, 
+                    text=True, 
+                    timeout=5
                 )
-                combined = (out.stdout + ' ' + out.stderr).strip()
-                if combined:
-                    match = re.search(r'(\d+\.\d+[\.\d]*\w*)', combined)
+                
+                combined = f"{proc.stdout}\n{proc.stderr}"
+                
+                if combined.strip():
+                    pattern = rf"{re.escape(name)}\s+(\d+\.\d+[\.\d]*\w*)"
+                    match = re.search(pattern, combined, re.IGNORECASE)
                     if match:
                         return match.group(1)
-            except (subprocess.TimeoutExpired, FileNotFoundError, OSError,
-                    PermissionError):
+                    
+                    versions = re.findall(r'(\d+\.\d+[\.\d]*\w*)', combined)
+                    for v in versions:
+                        if not v.startswith('20'):
+                            return v
+                            
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError, PermissionError):
                 continue
         return None
 


### PR DESCRIPTION
**Problem**
The previous implementation of _get_tool_version failed to detect version numbers for several key wireless auditing tools, specifically aircrack-ng, airodump-ng, and aireplay-ng.

Non-standard flags: These tools do not support --version or -v. When called with these flags, they output usage headers (containing the version) to stderr and exit with an error code, causing the previous logic to skip them.

The airmon-ng anomaly: This tool often reports wireless standards (e.g., 802.11a/b/g) in its help text, which were incorrectly parsed as the program's version number (resulting in v802.11a).

Changes
Unified Output Capture: The method now combines stdout and stderr (f"{proc.stdout}\n{proc.stderr}") to ensure headers are captured even when tools exit with an error status due to missing arguments.

Bare Invocation Support: Added an empty flag ('') to the search loop. This triggers the default usage/help header for tools in the Aircrack-ng suite, which is the most reliable way to retrieve their version string.

Anchored Regex: Updated the regex to rf"{re.escape(name)}\s+(\d+\.\d+[\.\d]*\w*)". By anchoring the search to the tool's name, we significantly reduce false positives from dates or IP addresses found elsewhere in the output.

Smart Filtering: Added a fallback mechanism that ignores common "false version" strings:

airmon-ng Exception: Explicitly set airmon-ng to return None for its version. After testing, it was determined that there is no consistent, cross-platform way to extract a clean version number for this specific script—even using apt list or dpkg is unreliable as it is often bundled within the larger aircrack-ng package or installed as a standalone script without metadata. Returning None prevents displaying misleading data like v802.11a.

Testing
Verified with sudo wifite --syscheck on Kali Linux.

Aircrack-ng suite: Now correctly reports v1.7.

Standard tools (iw, ip, reaver): Successfully restored version detection.

Airmon-ng: Now correctly displays the checkmark ✓ without the incorrect v802.11a string.