### PR TITLE
fix: improve version detection for aircrack-ng suite in syscheck

### DIFF
--- a/wifite/util/system_check.py
+++ b/wifite/util/system_check.py
@@ -281,6 +281,7 @@ class SystemCheck:
         return results
 
     def _get_tool_version(self, name: str) -> Optional[str]:
+        """Try to get version string for a tool."""
         if name == 'airmon-ng':
             if shutil.which(name):
                 return None

--- a/wifite/util/system_check.py
+++ b/wifite/util/system_check.py
@@ -281,7 +281,25 @@ class SystemCheck:
         return results
 
     def _get_tool_version(self, name: str) -> Optional[str]:
-        """Try to get version string for a tool."""
+        if name == 'airmon-ng':
+            if shutil.which(name):
+                return None
+            return None
+
+        aircrack_family = ['aircrack-ng', 'airodump-ng', 'aireplay-ng']
+        if name in aircrack_family:
+            try:
+                process = subprocess.run(
+                    [name], capture_output=True, text=True, timeout=5
+                )
+                output = (process.stdout + "\n" + process.stderr).splitlines()[:5]
+                content = " ".join(output)
+                match = re.search(r'(\d+\.\d+)', content)
+                if match:
+                    return match.group(1)
+            except Exception:
+                pass
+
         for flag in ['--version', '-v', '-V', 'version']:
             try:
                 out = subprocess.run(
@@ -292,8 +310,7 @@ class SystemCheck:
                     match = re.search(r'(\d+\.\d+[\.\d]*\w*)', combined)
                     if match:
                         return match.group(1)
-            except (subprocess.TimeoutExpired, FileNotFoundError, OSError,
-                    PermissionError):
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError, PermissionError):
                 continue
         return None
 


### PR DESCRIPTION
## Summary
This PR refactors the `_get_tool_version` method to ensure that tools from the **Aircrack-ng** suite (`aircrack-ng`, `airodump-ng`, `aireplay-ng`) correctly report their version numbers during the system readiness check (`--syscheck`).

## Changes
* **Aircrack-ng Suite Handling**: Added dedicated logic for the Aircrack-ng family that executes the binary without arguments to capture the version header from the initial output lines.
* **`airmon-ng` Specific Logic**: Modified handling for `airmon-ng` to return `None` if the binary is found via `shutil.which`, preventing "not installed" warnings while skipping complex version parsing for this specific script.
* **Improved Regex**: Updated the version extraction regex to `(\d+\.\d+)` to specifically target the `X.X` format, avoiding common collisions with copyright years (e.g., "2006-2022") often found in Aircrack-ng headers.
* **Output Capture**: The method now merges `stdout` and `stderr` and inspects the first 5 lines of output to ensure the version string is captured even if the tool exits with an error code when called without flags.

## Verification Results
Before this change, `wifite --syscheck` would show:
* `✓ aircrack-ng` (blank version)
* `✓ airodump-ng` (blank version)

After this change, the output correctly reflects the installed versions:
* `✓ aircrack-ng 1.7`
* `✓ airodump-ng 1.7`
* `✓ airmon-ng` (clean pass without version string)

Before Screenshot 
<img width="560" height="622" alt="Screenshot_2026-04-04_14-52-52" src="https://github.com/user-attachments/assets/21cd1fa5-3244-4e33-9621-bde102d17c1a" />
After Screenshot
<img width="533" height="619" alt="Screenshot_2026-04-04_14-53-07" src="https://github.com/user-attachments/assets/13c99f76-1eda-4ab2-8d61-19380f06c84c" />

