### PR TITLE
fix: replace subprocess which with shutil.which() in Process.exists()

### DIFF
--- a/wifite/util/process.py
+++ b/wifite/util/process.py
@@ -200,11 +200,7 @@ class Process:
         if Configuration.initialized and program in Configuration.existing_commands:
             return Configuration.existing_commands[program]
 
-        p2 = Process(['which', program])
-        stdout = p2.stdout().strip()
-        stderr = p2.stderr().strip()
-
-        exist = bool(stdout)
+        exist = shutil.which(program) is not None
         if Configuration.initialized:
             Configuration.existing_commands.update({program: exist})
         return exist

--- a/wifite/util/process.py
+++ b/wifite/util/process.py
@@ -204,7 +204,7 @@ class Process:
         stdout = p2.stdout().strip()
         stderr = p2.stderr().strip()
 
-        exist = not stdout == stderr == ''
+        exist = bool(stdout)
         if Configuration.initialized:
             Configuration.existing_commands.update({program: exist})
         return exist


### PR DESCRIPTION
## Summary

`Process.exists()` in `wifite/util/process.py` shelled out to the `which` binary via `Popen` to check if a tool is installed. This had three problems:

**1. Operator precedence bug (original crash)**
```python
exist = not stdout == stderr == ''
```
Evaluated as `not (stdout == stderr == '')`. When `which service` fails, stdout is `''` but stderr is `'service not found'` — so the chain returns `False`, `not False` → `True`, and wifite crashes trying to exec a missing binary.

**2. Fragile on minimal systems**
`which` is not present on Alpine, minimal Docker images, or some chroots. `Popen(['which', ...])` raises an unhandled `FileNotFoundError`, crashing every `exists()` call site.

**3. Inconsistent with the rest of the codebase**
`shutil` is already imported in this file. `_resolve_tool()` in the same class uses `shutil.which()`. So does `system_check.py` and `dependency.py`. The subprocess approach was the only outlier.

## Fix

Replace the entire subprocess block with a single in-process call:

```python
exist = shutil.which(program) is not None
```

This is correct, portable, and consistent with every other tool-detection pattern in the codebase.

## Test plan

- [ ] Run `wifite --kill` on a system where `service` is not installed (e.g. Arch Linux) — should no longer crash
- [ ] Verify tools that exist are still detected correctly (`aircrack-ng`, `tshark`, etc.)
- [ ] Verify tools that don't exist return `False` correctly