### PR TITLE
Potential fix for code scanning alert no. 16: Uncontrolled data used in path expression

### DIFF
--- a/wifite/attack/portal/server.py
+++ b/wifite/attack/portal/server.py
@@ -224,6 +224,10 @@ class PortalRequestHandler(BaseHTTPRequestHandler):
         try:
             # Remove /static/ prefix and ensure a relative path
             file_path = path[8:].lstrip('/\\')  # Remove '/static/' and any leading separators
+            if not file_path:
+                self._send_error_response(404, 'Not Found')
+                return
+
             filename = os.path.basename(file_path)
             
             # Try to get cached static file from server instance
@@ -247,6 +251,17 @@ class PortalRequestHandler(BaseHTTPRequestHandler):
             # Normalize static directory path
             static_dir = os.path.realpath(os.path.join(portal_dir, 'static'))
             # Build and normalize full path to requested file
+            full_path = os.path.realpath(os.path.join(static_dir, file_path))
+
+            # Enforce that the requested file stays under static_dir
+            if os.path.commonpath([static_dir, full_path]) != static_dir:
+                log_warning('Portal', f'Blocked path traversal attempt: {path}')
+                self._send_error_response(403, 'Forbidden')
+                return
+
+            if not os.path.isfile(full_path):
+                self._send_error_response(404, 'Not Found')
+                return
             full_path = os.path.realpath(os.path.join(static_dir, file_path))
             
             # Security check: ensure file is within static directory


### PR DESCRIPTION
Potential fix for [https://github.com/kimocoder/wifite2/security/code-scanning/16](https://github.com/kimocoder/wifite2/security/code-scanning/16)

To fix this safely without changing intended functionality, validate the resolved static file path against a trusted static root directory before serving content. In `_serve_static_file` (`wifite/attack/portal/server.py`), after deriving request-relative `file_path`, build `full_path` with `os.path.realpath(os.path.join(static_dir, file_path))` and then verify containment using `os.path.commonpath([static_dir, full_path]) == static_dir`. If validation fails, return 403 (or 404) and stop. Also reject empty paths and directories, and only read files if `os.path.isfile(full_path)`.

Best single approach: keep current behavior (cache first, filesystem fallback) but harden fallback with canonicalization + containment check. No new dependency is needed; use Python stdlib `os.path` only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
