### PR TITLE
Fix combined --no-pixie and --no-nullpin handling

### DIFF
--- a/tests/test_wps_config_parser.py
+++ b/tests/test_wps_config_parser.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Unit tests for WPS-specific command-line configuration."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from wifite.config.parsers.wps import parse_wps_args
+
+
+class TestWPSConfigParser(unittest.TestCase):
+    """Verify that independent WPS exclusions can be combined."""
+
+    @staticmethod
+    def _parse(**overrides):
+        class Config:
+            no_wps = False
+            wps_filter = False
+            wps_only = False
+            wps_pixie = True
+            wps_no_nullpin = True
+            wps_pin = True
+
+        values = {
+            'wps_filter': False,
+            'wps_only': False,
+            'no_wps': False,
+            'wps_pixie': False,
+            'wps_no_pixie': False,
+            'wps_no_nullpin': False,
+            'use_bully': False,
+            'use_reaver': False,
+            'wps_pixie_timeout': None,
+            'wps_fail_threshold': None,
+            'wps_timeout_threshold': None,
+            'wps_ignore_lock': False,
+        }
+        values.update(overrides)
+
+        with patch('wifite.config.parsers.wps.Color.pl'):
+            parse_wps_args(Config, SimpleNamespace(**values))
+        return Config
+
+    @staticmethod
+    def _enabled_attacks(config):
+        """Return effective Pixie, NULL PIN and regular PIN availability."""
+        return (
+            config.wps_pixie,
+            config.wps_pin and config.wps_no_nullpin,
+            config.wps_pin,
+        )
+
+    def test_wps_mode_flag_intersection_matrix(self):
+        # --pixie takes precedence over the contradictory --no-pixie flag,
+        # matching the parser's existing mode-selection behavior.
+        matrix = (
+            # --pixie, --no-pixie, --no-nullpin, raw config, enabled attacks
+            (False, False, False, (True, True, True), (True, True, True)),
+            (False, False, True,  (True, False, True), (True, False, True)),
+            (False, True,  False, (False, True, True), (False, True, True)),
+            (False, True,  True,  (False, False, True), (False, False, True)),
+            (True,  False, False, (True, True, False), (True, False, False)),
+            (True,  False, True,  (True, False, False), (True, False, False)),
+            (True,  True,  False, (True, True, False), (True, False, False)),
+            (True,  True,  True,  (True, False, False), (True, False, False)),
+        )
+
+        for pixie, no_pixie, no_nullpin, expected_config, expected_attacks in matrix:
+            with self.subTest(pixie=pixie, no_pixie=no_pixie, no_nullpin=no_nullpin):
+                config = self._parse(
+                    wps_pixie=pixie,
+                    wps_no_pixie=no_pixie,
+                    wps_no_nullpin=no_nullpin,
+                )
+                raw_config = (
+                    config.wps_pixie,
+                    config.wps_no_nullpin,
+                    config.wps_pin,
+                )
+
+                self.assertEqual(raw_config, expected_config)
+                self.assertEqual(self._enabled_attacks(config), expected_attacks)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wifite/config/parsers/wps.py
+++ b/wifite/config/parsers/wps.py
@@ -24,29 +24,26 @@ def parse_wps_args(cls, args):
         cls.wps_pin = False
         Color.pl('{+} {C}option:{W} will {O}never{W} use {C}WPS attacks{W} (Pixie-Dust/PIN) on targets')
 
-    elif args.wps_pixie:
-        # WPS Pixie-Dust only
-        cls.no_wps = False  # Explicitly ensure WPS attacks are enabled
-        cls.wps_pixie = True
-        cls.wps_no_nullpin = True
-        cls.wps_pin = False
-        Color.pl('{+} {C}option:{W} will {G}only{W} use {C}WPS Pixie-Dust attack{W} (no {O}PIN{W}) on targets')
+    else:
+        if args.wps_pixie:
+            # WPS Pixie-Dust only
+            cls.no_wps = False  # Explicitly ensure WPS attacks are enabled
+            cls.wps_pixie = True
+            cls.wps_no_nullpin = True
+            cls.wps_pin = False
+            Color.pl('{+} {C}option:{W} will {G}only{W} use {C}WPS Pixie-Dust attack{W} (no {O}PIN{W}) on targets')
 
-    elif args.wps_no_nullpin:
-        # WPS NULL PIN only
-        cls.no_wps = False  # Explicitly ensure WPS attacks are enabled
-        cls.wps_pixie = True
-        cls.wps_no_nullpin = False
-        cls.wps_pin = True
-        Color.pl('{+} {C}option:{W} will {G}not{W} use {C}WPS NULL PIN attack{W} (no {O}PIN{W}) on targets')
+        elif args.wps_no_pixie:
+            # WPS PIN only
+            cls.no_wps = False  # Explicitly ensure WPS attacks are enabled
+            cls.wps_pixie = False
+            cls.wps_pin = True
+            Color.pl('{+} {C}option:{W} will {G}only{W} use {C}WPS PIN attack{W} (no {O}Pixie-Dust{W}) on targets')
 
-    elif args.wps_no_pixie:
-        # WPS PIN only
-        cls.no_wps = False  # Explicitly ensure WPS attacks are enabled
-        cls.wps_pixie = False
-        cls.wps_no_nullpin = True
-        cls.wps_pin = True
-        Color.pl('{+} {C}option:{W} will {G}only{W} use {C}WPS PIN attack{W} (no {O}Pixie-Dust{W}) on targets')
+        if args.wps_no_nullpin:
+            # NULL PIN is independent of the selected WPS attack mode.
+            cls.wps_no_nullpin = False
+            Color.pl('{+} {C}option:{W} will {O}never{W} use {C}WPS NULL PIN attack{W} on targets')
 
     if args.use_bully:
         from ...tools.bully import Bully


### PR DESCRIPTION
Fixes WPS argument parsing when `--no-pixie` and `--no-nullpin` are used together.

Previously, `--no-nullpin` took precedence and re-enabled Pixie Dust. The flags are now handled independently.

Added a unit-test matrix covering all combinations of `--pixie`, `--no-pixie`, and `--no-nullpin`.
