### PR TITLE
Fix WPS option restoration in resumed sessions

### DIFF
--- a/tests/test_config_restoration.py
+++ b/tests/test_config_restoration.py
@@ -27,6 +27,7 @@ class TestConfigurationRestoration(unittest.TestCase):
         self.config.wordlist = '/usr/share/wordlists/rockyou.txt'
         self.config.wpa_attack_timeout = 500
         self.config.wps_pixie = True
+        self.config.wps_no_nullpin = True
         self.config.wps_pin = True
         self.config.dont_use_pmkid = False
         self.config.wps_only = False
@@ -57,6 +58,7 @@ class TestConfigurationRestoration(unittest.TestCase):
                 'wordlist': '/custom/wordlist.txt',
                 'wpa_attack_timeout': 600,
                 'wps_pixie': False,
+                'wps_no_nullpin': False,
                 'wps_pin': False,
                 'use_pmkid': True,
                 'wps_only': False,
@@ -79,7 +81,7 @@ class TestConfigurationRestoration(unittest.TestCase):
         )
         
         # Mock subprocess to simulate interface check
-        with patch('subprocess.run') as mock_run:
+        with patch('wifite.util.process.Process.run_simple') as mock_run:
             mock_run.return_value = Mock(
                 stdout='Interface wlan1mon\n',
                 returncode=0
@@ -93,6 +95,7 @@ class TestConfigurationRestoration(unittest.TestCase):
         self.assertEqual(self.config.wordlist, '/custom/wordlist.txt')
         self.assertEqual(self.config.wpa_attack_timeout, 600)
         self.assertFalse(self.config.wps_pixie)
+        self.assertFalse(self.config.wps_no_nullpin)
         self.assertFalse(self.config.wps_pin)
         self.assertFalse(self.config.dont_use_pmkid)  # use_pmkid=True means dont_use_pmkid=False
         self.assertTrue(self.config.use_pmkid_only)
@@ -129,7 +132,7 @@ class TestConfigurationRestoration(unittest.TestCase):
         )
         
         # Mock subprocess to simulate interface not found
-        with patch('subprocess.run') as mock_run:
+        with patch('wifite.util.process.Process.run_simple') as mock_run:
             mock_run.return_value = Mock(
                 stdout='Interface wlan0mon\nInterface wlan1mon\n',
                 returncode=0
@@ -148,6 +151,9 @@ class TestConfigurationRestoration(unittest.TestCase):
         # Set different values in config (simulating command-line flags)
         self.config.wordlist = '/different/wordlist.txt'
         self.config.wpa_attack_timeout = 300
+        self.config.wps_pixie = False
+        self.config.wps_no_nullpin = False
+        self.config.wps_pin = False
         self.config.use_tui = False
         
         session = SessionState(
@@ -158,6 +164,9 @@ class TestConfigurationRestoration(unittest.TestCase):
                 'interface': 'wlan0mon',
                 'wordlist': '/original/wordlist.txt',
                 'wpa_attack_timeout': 600,
+                'wps_pixie': True,
+                'wps_no_nullpin': True,
+                'wps_pin': True,
                 'use_tui': True
             },
             targets=[
@@ -173,7 +182,7 @@ class TestConfigurationRestoration(unittest.TestCase):
         )
         
         # Mock subprocess
-        with patch('subprocess.run') as mock_run:
+        with patch('wifite.util.process.Process.run_simple') as mock_run:
             mock_run.return_value = Mock(
                 stdout='Interface wlan0mon\n',
                 returncode=0
@@ -184,11 +193,38 @@ class TestConfigurationRestoration(unittest.TestCase):
         
         # Should have conflicts detected
         self.assertGreater(len(result['conflicts']), 0)
+        self.assertTrue(any('--pixie/--no-pixie' in conflict for conflict in result['conflicts']))
+        self.assertTrue(any('--no-nullpin' in conflict for conflict in result['conflicts']))
+        self.assertTrue(any('WPS PIN mode' in conflict for conflict in result['conflicts']))
         
         # Configuration should be overridden with session values
         self.assertEqual(self.config.wordlist, '/original/wordlist.txt')
         self.assertEqual(self.config.wpa_attack_timeout, 600)
+        self.assertTrue(self.config.wps_pixie)
+        self.assertTrue(self.config.wps_no_nullpin)
+        self.assertTrue(self.config.wps_pin)
         self.assertTrue(self.config.use_tui)
+
+    def test_create_session_preserves_wps_configuration(self):
+        """Test that all WPS mode settings are stored in a new session."""
+        target = Mock(
+            bssid='AA:BB:CC:DD:EE:FF',
+            essid='TestNetwork',
+            channel=6,
+            encryption='WPA2',
+            power=50,
+            wps=True,
+        )
+        config = Mock()
+        config.wps_pixie = False
+        config.wps_no_nullpin = False
+        config.wps_pin = True
+
+        session = self.session_mgr.create_session([target], config)
+
+        self.assertFalse(session.config['wps_pixie'])
+        self.assertFalse(session.config['wps_no_nullpin'])
+        self.assertTrue(session.config['wps_pin'])
     
     def test_interface_check_failure(self):
         """Test handling when interface check fails."""
@@ -213,7 +249,7 @@ class TestConfigurationRestoration(unittest.TestCase):
         )
         
         # Mock subprocess to raise exception
-        with patch('subprocess.run') as mock_run:
+        with patch('wifite.util.process.Process.run_simple') as mock_run:
             mock_run.side_effect = FileNotFoundError('iw command not found')
             
             # Restore configuration
@@ -249,9 +285,10 @@ class TestConfigurationRestoration(unittest.TestCase):
         # Store original values
         original_wordlist = self.config.wordlist
         original_timeout = self.config.wpa_attack_timeout
+        original_wps_no_nullpin = self.config.wps_no_nullpin
         
         # Mock subprocess
-        with patch('subprocess.run') as mock_run:
+        with patch('wifite.util.process.Process.run_simple') as mock_run:
             mock_run.return_value = Mock(
                 stdout='Interface wlan0mon\n',
                 returncode=0
@@ -263,6 +300,7 @@ class TestConfigurationRestoration(unittest.TestCase):
         # Original values should be preserved when not in session
         self.assertEqual(self.config.wordlist, original_wordlist)
         self.assertEqual(self.config.wpa_attack_timeout, original_timeout)
+        self.assertEqual(self.config.wps_no_nullpin, original_wps_no_nullpin)
         
         # Interface should still be restored
         self.assertEqual(self.config.interface, 'wlan0mon')

--- a/tests/test_wps_config_parser.py
+++ b/tests/test_wps_config_parser.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Unit tests for WPS-specific command-line configuration."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from wifite.config.parsers.wps import parse_wps_args
+
+
+class TestWPSConfigParser(unittest.TestCase):
+    """Verify that independent WPS exclusions can be combined."""
+
+    @staticmethod
+    def _parse(**overrides):
+        class Config:
+            no_wps = False
+            wps_filter = False
+            wps_only = False
+            wps_pixie = True
+            wps_no_nullpin = True
+            wps_pin = True
+
+        values = {
+            'wps_filter': False,
+            'wps_only': False,
+            'no_wps': False,
+            'wps_pixie': False,
+            'wps_no_pixie': False,
+            'wps_no_nullpin': False,
+            'use_bully': False,
+            'use_reaver': False,
+            'wps_pixie_timeout': None,
+            'wps_fail_threshold': None,
+            'wps_timeout_threshold': None,
+            'wps_ignore_lock': False,
+        }
+        values.update(overrides)
+
+        with patch('wifite.config.parsers.wps.Color.pl'):
+            parse_wps_args(Config, SimpleNamespace(**values))
+        return Config
+
+    @staticmethod
+    def _enabled_attacks(config):
+        """Return effective Pixie, NULL PIN and regular PIN availability."""
+        return (
+            config.wps_pixie,
+            config.wps_pin and config.wps_no_nullpin,
+            config.wps_pin,
+        )
+
+    def test_wps_mode_flag_intersection_matrix(self):
+        # --pixie takes precedence over the contradictory --no-pixie flag,
+        # matching the parser's existing mode-selection behavior.
+        matrix = (
+            # --pixie, --no-pixie, --no-nullpin, raw config, enabled attacks
+            (False, False, False, (True, True, True), (True, True, True)),
+            (False, False, True,  (True, False, True), (True, False, True)),
+            (False, True,  False, (False, True, True), (False, True, True)),
+            (False, True,  True,  (False, False, True), (False, False, True)),
+            (True,  False, False, (True, True, False), (True, False, False)),
+            (True,  False, True,  (True, False, False), (True, False, False)),
+            (True,  True,  False, (True, True, False), (True, False, False)),
+            (True,  True,  True,  (True, False, False), (True, False, False)),
+        )
+
+        for pixie, no_pixie, no_nullpin, expected_config, expected_attacks in matrix:
+            with self.subTest(pixie=pixie, no_pixie=no_pixie, no_nullpin=no_nullpin):
+                config = self._parse(
+                    wps_pixie=pixie,
+                    wps_no_pixie=no_pixie,
+                    wps_no_nullpin=no_nullpin,
+                )
+                raw_config = (
+                    config.wps_pixie,
+                    config.wps_no_nullpin,
+                    config.wps_pin,
+                )
+
+                self.assertEqual(raw_config, expected_config)
+                self.assertEqual(self._enabled_attacks(config), expected_attacks)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wifite/config/parsers/wps.py
+++ b/wifite/config/parsers/wps.py
@@ -24,29 +24,26 @@ def parse_wps_args(cls, args):
         cls.wps_pin = False
         Color.pl('{+} {C}option:{W} will {O}never{W} use {C}WPS attacks{W} (Pixie-Dust/PIN) on targets')
 
-    elif args.wps_pixie:
-        # WPS Pixie-Dust only
-        cls.no_wps = False  # Explicitly ensure WPS attacks are enabled
-        cls.wps_pixie = True
-        cls.wps_no_nullpin = True
-        cls.wps_pin = False
-        Color.pl('{+} {C}option:{W} will {G}only{W} use {C}WPS Pixie-Dust attack{W} (no {O}PIN{W}) on targets')
+    else:
+        if args.wps_pixie:
+            # WPS Pixie-Dust only
+            cls.no_wps = False  # Explicitly ensure WPS attacks are enabled
+            cls.wps_pixie = True
+            cls.wps_no_nullpin = True
+            cls.wps_pin = False
+            Color.pl('{+} {C}option:{W} will {G}only{W} use {C}WPS Pixie-Dust attack{W} (no {O}PIN{W}) on targets')
 
-    elif args.wps_no_nullpin:
-        # WPS NULL PIN only
-        cls.no_wps = False  # Explicitly ensure WPS attacks are enabled
-        cls.wps_pixie = True
-        cls.wps_no_nullpin = False
-        cls.wps_pin = True
-        Color.pl('{+} {C}option:{W} will {G}not{W} use {C}WPS NULL PIN attack{W} (no {O}PIN{W}) on targets')
+        elif args.wps_no_pixie:
+            # WPS PIN only
+            cls.no_wps = False  # Explicitly ensure WPS attacks are enabled
+            cls.wps_pixie = False
+            cls.wps_pin = True
+            Color.pl('{+} {C}option:{W} will {G}only{W} use {C}WPS PIN attack{W} (no {O}Pixie-Dust{W}) on targets')
 
-    elif args.wps_no_pixie:
-        # WPS PIN only
-        cls.no_wps = False  # Explicitly ensure WPS attacks are enabled
-        cls.wps_pixie = False
-        cls.wps_no_nullpin = True
-        cls.wps_pin = True
-        Color.pl('{+} {C}option:{W} will {G}only{W} use {C}WPS PIN attack{W} (no {O}Pixie-Dust{W}) on targets')
+        if args.wps_no_nullpin:
+            # NULL PIN is independent of the selected WPS attack mode.
+            cls.wps_no_nullpin = False
+            Color.pl('{+} {C}option:{W} will {O}never{W} use {C}WPS NULL PIN attack{W} on targets')
 
     if args.use_bully:
         from ...tools.bully import Bully

--- a/wifite/util/session.py
+++ b/wifite/util/session.py
@@ -331,6 +331,7 @@ class SessionManager:
                 'wordlist': getattr(config, 'wordlist', None),
                 'wpa_attack_timeout': getattr(config, 'wpa_attack_timeout', 500),
                 'wps_pixie': getattr(config, 'wps_pixie', True),
+                'wps_no_nullpin': getattr(config, 'wps_no_nullpin', True),
                 'wps_pin': getattr(config, 'wps_pin', True),
                 'use_pmkid': not getattr(config, 'dont_use_pmkid', False),
                 'infinite_mode': getattr(config, 'infinite_mode', False),
@@ -948,11 +949,31 @@ class SessionManager:
         # WPS Pixie
         saved_wps_pixie = saved_config.get('wps_pixie')
         if saved_wps_pixie is not None:
+            current_wps_pixie = getattr(config_obj, 'wps_pixie', True)
+            if current_wps_pixie != saved_wps_pixie:
+                conflicts.append(
+                    "--pixie/--no-pixie: command-line value overridden by session value"
+                )
             config_obj.wps_pixie = saved_wps_pixie
-        
+
+        # WPS NULL PIN
+        saved_wps_no_nullpin = saved_config.get('wps_no_nullpin')
+        if saved_wps_no_nullpin is not None:
+            current_wps_no_nullpin = getattr(config_obj, 'wps_no_nullpin', True)
+            if current_wps_no_nullpin != saved_wps_no_nullpin:
+                conflicts.append(
+                    "--no-nullpin: command-line value overridden by session value"
+                )
+            config_obj.wps_no_nullpin = saved_wps_no_nullpin
+
         # WPS PIN
         saved_wps_pin = saved_config.get('wps_pin')
         if saved_wps_pin is not None:
+            current_wps_pin = getattr(config_obj, 'wps_pin', True)
+            if current_wps_pin != saved_wps_pin:
+                conflicts.append(
+                    "WPS PIN mode: command-line value overridden by session value"
+                )
             config_obj.wps_pin = saved_wps_pin
         
         # PMKID


### PR DESCRIPTION
Preserve `wps_no_nullpin` alongside the existing WPS options when creating and restoring sessions.

Previously, sessions started with `--no-nullpin` could resume with NULL PIN enabled. WPS option overrides are now also reported as configuration conflicts.

Added tests for WPS configuration persistence, restoration, conflict reporting, and backward compatibility with older sessions.
