### PR TITLE
Potential fix for code scanning alert no. 826: Uncontrolled data used in path expression

### DIFF
--- a/wifite/attack/portal/server.py
+++ b/wifite/attack/portal/server.py
@@ -223,18 +223,23 @@ class PortalRequestHandler(BaseHTTPRequestHandler):
         """Serve static files (CSS, images, etc.) with caching optimization."""
         try:
             # Remove /static/ prefix and ensure a relative path
-            file_path = path[8:].lstrip('/\\')  # Remove '/static/' and any leading separators
-            if not file_path:
+            requested_path = path[8:].lstrip('/\\')  # Remove '/static/' and any leading separators
+            if not requested_path:
                 self._send_error_response(404, 'Not Found')
                 return
 
-            filename = os.path.basename(file_path)
-            
+            # Only allow direct files under static/ (no subdirectories)
+            filename = os.path.basename(requested_path)
+            if requested_path != filename:
+                log_warning('Portal', f'Blocked non-file static path request: {path}')
+                self._send_error_response(403, 'Forbidden')
+                return
+
             # Try to get cached static file from server instance
             cached = None
             if self.server_instance:
                 cached = self.server_instance.get_cached_static(filename)
-            
+
             if cached:
                 # Serve from cache (much faster)
                 content, content_type = cached
@@ -245,13 +250,11 @@ class PortalRequestHandler(BaseHTTPRequestHandler):
                 self.end_headers()
                 self.wfile.write(content)
                 return
-            
+
             # Fallback to file system if not cached
             portal_dir = os.path.dirname(os.path.abspath(__file__))
-            # Normalize static directory path
             static_dir = os.path.realpath(os.path.join(portal_dir, 'static'))
-            # Build and normalize full path to requested file
-            full_path = os.path.realpath(os.path.join(static_dir, file_path))
+            full_path = os.path.realpath(os.path.join(static_dir, filename))
 
             # Enforce that the requested file stays under static_dir
             if os.path.commonpath([static_dir, full_path]) != static_dir:
@@ -259,17 +262,12 @@ class PortalRequestHandler(BaseHTTPRequestHandler):
                 self._send_error_response(403, 'Forbidden')
                 return
 
+            # Check if file exists
             if not os.path.isfile(full_path):
                 self._send_error_response(404, 'Not Found')
                 return
-            full_path = os.path.realpath(os.path.join(static_dir, file_path))
-            
-            # Security check: ensure file is within static directory
-            if os.path.commonpath([static_dir, full_path]) != static_dir:
-                self._send_error_response(403, 'Forbidden')
-                return
-            
-            # Check if file exists
+
+            # Determine content type
             if not os.path.exists(full_path):
                 self._send_error_response(404, 'Not Found')
                 return


### PR DESCRIPTION
Potential fix for [https://github.com/kimocoder/wifite2/security/code-scanning/826](https://github.com/kimocoder/wifite2/security/code-scanning/826)

Use a stricter allowlist-style approach for static assets: serve only files directly under `static/` by filename, rejecting any request containing path separators or traversal-like forms. This preserves current behavior (the code already caches by `filename = os.path.basename(file_path)`) while eliminating uncontrolled path composition.

Best single fix in `wifite/attack/portal/server.py` (`_serve_static_file`):
1. Normalize requested segment (`path[8:]`) and reject empty input.
2. Require the normalized request to equal `os.path.basename(...)` (no subdirectories).
3. Use that safe basename for both cache lookup and filesystem join.
4. Build `full_path` from `static_dir + safe_name`, canonicalize once, do one containment check, then `isfile`.

This removes the duplicate `full_path` rebuild and duplicate commonpath check, and ensures the sink only receives a validated filename.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
